### PR TITLE
Package cadvisor

### DIFF
--- a/code/agent/src/main/resources/META-INF/cattle/agent-resources/defaults.properties
+++ b/code/agent/src/main/resources/META-INF/cattle/agent-resources/defaults.properties
@@ -1,3 +1,3 @@
 agent.packages.types=pyagent,node-services
-agent.packages.pyagent=host-api,agent-binaries,console-agent,python-agent
+agent.packages.pyagent=host-api,agent-binaries,console-agent,python-agent,cadvisor
 agent.packages.node.services=node-agent

--- a/resources/content/cattle-global.properties
+++ b/resources/content/cattle-global.properties
@@ -10,6 +10,7 @@ agent.package.agent.binaries.url=https://github.com/rancherio/agent-binaries/rel
 agent.package.node.agent.url=https://github.com/rancherio/node-agent/releases/download/v0.1.0/node-agent.tar.gz
 agent.package.console.agent.url=https://github.com/rancherio/console-agent/releases/download/v0.2.1/console-agent.tar.gz
 agent.package.host.api.url=https://github.com/rancherio/host-api/releases/download/v0.2.1/host-api.tar.gz
+agent.package.cadvisor.url=https://github.com/rancherio/cadvisor-package/releases/download/v0.1.0/cadvisor.tar.gz
 
 ####################
 # General Settings #


### PR DESCRIPTION
The cadvisor binary is currently packaged in python-agent.  This PR configures cattle to download the binary on demand.