### PR TITLE
Avoid agent timing out before server starts

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -15,7 +15,7 @@ if [ -x "$(which wrapdocker)" ]; then
     docker info
 fi
 
-DEV_HOST=localhost:8081 ../tools/development/register-boot2docker.sh >/tmp/register.log &
+docker pull rancher/agent 
 
 run()
 {
@@ -32,6 +32,9 @@ run()
 run ./bootstrap
 run ./clean
 MAVEN_ARGS='-B -q' ./build
+
+DEV_HOST=localhost:8081 ../tools/development/register-boot2docker.sh >/tmp/register.log &
+
 run ./run --background
 
 ./test || {

--- a/tools/development/register-boot2docker.sh
+++ b/tools/development/register-boot2docker.sh
@@ -2,6 +2,7 @@
 set -e
 
 DEV_HOST=${DEV_HOST:-10.0.2.2:8080}
+AGENT_IMAGE=${AGENT_IMAGE:-rancher/agent}
 
 # This is just here to make sure your environment is sane
 docker info
@@ -11,4 +12,4 @@ if [ -t 1 ]; then
     CONSOLE_ARGS="-it"
 fi
 
-docker run $DOCKER_ARGS --rm $CONSOLE_ARGS -v /var/run/docker.sock:/var/run/docker.sock rancher/agent http://${DEV_HOST}
+docker run $DOCKER_ARGS --rm $CONSOLE_ARGS -v /var/run/docker.sock:/var/run/docker.sock $AGENT_IMAGE http://${DEV_HOST}


### PR DESCRIPTION
During the server/ci process it is possible for the server to agent to give up looking for the server while the build is going on. This has been observed on the Mac with VBox/Boot2docker. The change here just does a docker pull upfront, and then starts the agent right before the server is fired up.

Also, made it possible to specify the rancher/agent image via an Environment variable. This is going to be useful as we lock down dependencies.