### PR TITLE
[Issue #80] - Change support type for CpuShares to integer

### DIFF
--- a/resources/content/schema/base/container.json
+++ b/resources/content/schema/base/container.json
@@ -159,6 +159,10 @@
             "type": "string",
             "nullable": true
         },
+        "cpuShares": {
+            "type": "int",
+            "nullable": true
+        },
         "stdinOpen": {
             "type": "boolean",
             "default": false
@@ -174,10 +178,6 @@
         "lxcConf": {
             "type": "map[string]",
             "nullable": true       
-        },
-        "cpuShares": {
-            "type": "float",
-            "nullable": true
         },
         "restartPolicy":{
             "type": "json",


### PR DESCRIPTION
Changed the type for CpuShares from "float" to integer.