### PR TITLE
Add resource type as top level key of reply event

### DIFF
--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/handler/AgentBasedProcessHandler.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/handler/AgentBasedProcessHandler.java
@@ -132,10 +132,19 @@ public class AgentBasedProcessHandler extends AbstractObjectProcessHandler imple
 
         postProcessEvent(event, reply, state, process, eventResource, dataResource, agentResource);
 
-        return new HandlerResult(shouldContinue, CollectionUtils.castMap(reply.getData()));
+        return new HandlerResult(shouldContinue, getResourceDataMap(getObjectManager().getType(eventResource), reply.getData()));
     }
 
-    protected void postProcessEvent(EventVO<?> event, Event reply, ProcessState state, ProcessInstance process,
+    protected Map<Object, Object> getResourceDataMap(String type, Object data) {
+    	Object map = CollectionUtils.castMap(data).get(type);
+    	if (map instanceof Map) {
+    		return (Map<Object, Object>) map;
+    	}
+
+    	return null;
+    }
+
+	protected void postProcessEvent(EventVO<?> event, Event reply, ProcessState state, ProcessInstance process,
             Object eventResource, Object dataResource, Object agentResource) {
     }
 


### PR DESCRIPTION
Fixes the issue #161

Currently the request event and reply event's format are inconsistent. The
request event would contained a map as data, using the resource type as the top
level key, but in the reply event's data, the top level is the fields of
resources, rather than resource itself. The inconsistent is very confusing for
agent communication.

This patch would enable the agent to send reply event with consistent format as
request event, say the top level key would be resource type itself, rather than
fields of resource.