### PR TITLE
Prevent admin user from listing all resources

### DIFF
--- a/code/framework/api/src/main/java/io/cattle/platform/api/auth/Policy.java
+++ b/code/framework/api/src/main/java/io/cattle/platform/api/auth/Policy.java
@@ -5,6 +5,7 @@ import java.util.List;
 public interface Policy {
 
     public static final String AGENT_ID = "agentId";
+    public static final String LIST_ALL_ACCOUNTS = "list.all.accounts";
     public static final String AUTHORIZED_FOR_ALL_ACCOUNTS = "all.accounts";
     public static final String REMOVED_VISIBLE = "removed.visible";
     public static final String PLAIN_ID = "plain.id";

--- a/code/framework/api/src/main/java/io/cattle/platform/api/resource/jooq/AbstractJooqResourceManager.java
+++ b/code/framework/api/src/main/java/io/cattle/platform/api/resource/jooq/AbstractJooqResourceManager.java
@@ -322,10 +322,14 @@ public abstract class AbstractJooqResourceManager extends AbstractObjectResource
     }
 
     @Override
-    protected void addAccountAuthorization(String type, Map<Object, Object> criteria, Policy policy) {
-        super.addAccountAuthorization(type, criteria, policy);
+    protected void addAccountAuthorization(boolean byId, boolean byLink, String type, Map<Object, Object> criteria, Policy policy) {
+        super.addAccountAuthorization(byId, byLink, type, criteria, policy);
 
-        if ( ! policy.isOption(Policy.AUTHORIZED_FOR_ALL_ACCOUNTS) ) {
+        if ( ! policy.isOption(Policy.LIST_ALL_ACCOUNTS) ) {
+            if ( policy.isOption(Policy.AUTHORIZED_FOR_ALL_ACCOUNTS) && (byId || byLink) ) {
+                return;
+            }
+
             TableField<?, Object> accountField = JooqUtils.getTableField(getMetaDataManager(), type, ObjectMetaDataManager.ACCOUNT_FIELD);
             TableField<?, Object> publicField = JooqUtils.getTableField(getMetaDataManager(), type, ObjectMetaDataManager.PUBLIC_FIELD);
             Object accountValue = criteria.get(ObjectMetaDataManager.ACCOUNT_FIELD);

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/manager/DataManager.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/manager/DataManager.java
@@ -19,8 +19,8 @@ public class DataManager extends AbstractJooqResourceManager {
     }
 
     @Override
-    protected Map<Object, Object> getDefaultCriteria(boolean byId, String type) {
-        Map<Object, Object> criteria = super.getDefaultCriteria(byId, type);
+    protected Map<Object, Object> getDefaultCriteria(boolean byId, boolean byLink, String type) {
+        Map<Object, Object> criteria = super.getDefaultCriteria(byId, byLink, type);
         criteria.put(DataTable.DATA.VISIBLE, true);
 
         return criteria;

--- a/code/iaas/api-logic/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
+++ b/code/iaas/api-logic/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
@@ -32,11 +32,13 @@ agent.filter.default.user=root
 
 account.by.key.credential.types=agentApiKey, apiKey, usernamePassword
 
+account.type.admin.list.all.accounts=false
 account.type.admin.all.accounts=true
 account.type.admin.plain.id.option=true
 account.type.admin.subscription.style=raw
 account.type.agent.plain.id=true
 account.type.readAdmin.subscription.style=raw
+account.type.superadmin.list.all.accounts=true
 account.type.superadmin.all.accounts=true
 account.type.superadmin.plain.id.option=true
 account.type.superadmin.subscription.style=raw

--- a/code/meta-parent/pom.xml
+++ b/code/meta-parent/pom.xml
@@ -378,7 +378,7 @@
             <dependency>
                 <groupId>io.github.ibuildthecloud</groupId>
                 <artifactId>gdapi-java-server</artifactId>
-                <version>0.6.0</version>
+                <version>0.8.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-collections</groupId>

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -148,8 +148,6 @@
         "volume.isHostPath" : "r",
         "volume.uri" : "r",
 
-        "zone" : "crud",
-        
         "end" : ""
     }
 }

--- a/tests/integration/cattletest/core/common_fixtures.py
+++ b/tests/integration/cattletest/core/common_fixtures.py
@@ -346,11 +346,11 @@ def get_plain_id(admin_client, obj):
     return ret[0].id
 
 
-def get_by_plain_id(admin_client, type, id):
-    obj = admin_client.by_id(type, id, _plainId='true')
+def get_by_plain_id(super_client, type, id):
+    obj = super_client.by_id(type, id, _plainId='true')
     if obj is None:
         return None
-    objs = admin_client.list(type, uuid=obj.uuid)
+    objs = super_client.list(type, uuid=obj.uuid)
     if len(objs) == 0:
         return None
     return objs[0]

--- a/tests/integration/cattletest/core/test_api.py
+++ b/tests/integration/cattletest/core/test_api.py
@@ -204,17 +204,17 @@ def test_schema_self_link(admin_client):
     assert con_schema.links.self.startswith("http")
 
 
-def test_child_map_include(admin_client, sim_context):
+def test_child_map_include(super_client, sim_context):
     image_uuid = sim_context['imageUuid']
-    container = admin_client.create_container(imageUuid=image_uuid)
-    container = wait_success(admin_client, container)
+    container = super_client.create_container(imageUuid=image_uuid)
+    container = wait_success(super_client, container)
 
-    cs = admin_client.list_container(uuid=container.uuid, include='hosts')
+    cs = super_client.list_container(uuid=container.uuid, include='hosts')
 
     assert cs[0].hosts[0].uuid is not None
     assert len(cs[0].hosts) == 1
 
-    hs = admin_client.list_host(uuid=cs[0].hosts[0].uuid,
+    hs = super_client.list_host(uuid=cs[0].hosts[0].uuid,
                                 include='instances')
 
     found = False

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -45,14 +45,12 @@ def test_host_auth(admin_client, client):
         'accountId': 'r',
         'agentId': 'r',
         'computeTotal': 'r',
-        'zoneId': 'ru',
         'data': 'r',
     })
 
     auth_check(client.schema, 'host', 'rud', {
         'accountId': 'r',
         'computeTotal': 'r',
-        'zoneId': 'ru',
         'agentId': 'r',
     })
 

--- a/tests/integration/cattletest/core/test_register.py
+++ b/tests/integration/cattletest/core/test_register.py
@@ -22,7 +22,7 @@ def test_register_create(admin_client, super_client):
     assert r.accessKey is not None
     assert r.secretKey is not None
 
-    agent = get_by_plain_id(admin_client, 'agent', r.data.agentId)
+    agent = get_by_plain_id(super_client, 'agent', r.data.agentId)
 
     raw_account_id = get_plain_id(admin_client, r.account())
 

--- a/tests/integration/cattletest/core/test_zone.py
+++ b/tests/integration/cattletest/core/test_zone.py
@@ -1,9 +1,6 @@
 from common_fixtures import *  # NOQA
 
 
-def test_zone_list(admin_client, client):
-    zones = admin_client.list_zone()
+def test_zone_list(super_client):
+    zones = super_client.list_zone()
     assert len(zones) > 0
-
-    zones = client.list_zone()
-    assert len(zones) >= 0


### PR DESCRIPTION
Only resource that belong to admin are listed by default.  Admin can still
access and modify any resource in the system, just listing is filtered.
For resources that do not have an accountId field, they are shown to the
admin account.  For example settings or accounts themself.