### PR TITLE
Add resource type as top level key of reply event

### DIFF
--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/handler/AgentBasedProcessHandler.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/handler/AgentBasedProcessHandler.java
@@ -132,10 +132,16 @@ public class AgentBasedProcessHandler extends AbstractObjectProcessHandler imple
 
         postProcessEvent(event, reply, state, process, eventResource, dataResource, agentResource);
 
-        return new HandlerResult(shouldContinue, CollectionUtils.castMap(reply.getData()));
+        return new HandlerResult(shouldContinue,
+        		getResourceDataMap(getObjectManager().getType(eventResource), reply.getData()));
     }
 
-    protected void postProcessEvent(EventVO<?> event, Event reply, ProcessState state, ProcessInstance process,
+    @SuppressWarnings("unchecked")
+    protected Map<Object, Object> getResourceDataMap(String type, Object data) {
+    	return (Map<Object, Object>)CollectionUtils.toMap(data).get(type);
+    }
+
+	protected void postProcessEvent(EventVO<?> event, Event reply, ProcessState state, ProcessInstance process,
             Object eventResource, Object dataResource, Object agentResource) {
     }
 

--- a/docs/examples/handler-bash/hypervisor.sh
+++ b/docs/examples/handler-bash/hypervisor.sh
@@ -130,8 +130,10 @@ event_handler_storage_image_activate()
     create_file image $pool_uuid $image_uuid
 
     reply '{
-        "image" : {
-            "format" : "touch"
+        "imageStoragePoolMap" : {
+            "image" : {
+                "format" : "touch"
+            }
         }
     }'
 }
@@ -145,8 +147,10 @@ event_handler_storage_volume_activate()
     create_file volume $pool_uuid $volume_uuid
 
     reply '{
-        "volume" : {
-            "format" : "touch"
+        "volumeStoragePoolMap" : {
+            "volume" : {
+                "format" : "touch"
+            }
         }
     }'
 }


### PR DESCRIPTION
Fixes the issue #161

Currently the request event and reply event's format are inconsistent. The
request event would contained a map as data, using the resource type as the top
level key, but in the reply event's data, the top level is the fields of
resources, rather than resource itself. The inconsistent is very confusing for
agent communication.

This patch would enable the agent to send reply event with consistent format as
request event, say the top level key would be resource type itself, rather than
fields of resource.

The patch updated example bash as well.