### PR TITLE
Bump API-UI version

### DIFF
--- a/resources/content/cattle-global.properties
+++ b/resources/content/cattle-global.properties
@@ -3,8 +3,8 @@
 ####################
 
 api.ui.index=http://cdn.rancher.io/ui/0.7.3/static/index.html
-api.ui.js.url=http://cdn.rancher.io/api-ui/1.0.1/ui.min.js
-api.ui.css.url=http://cdn.rancher.io/api-ui/1.0.1/ui.min.css
+api.ui.js.url=http://cdn.rancher.io/api-ui/1.0.2/ui.min.js
+api.ui.css.url=http://cdn.rancher.io/api-ui/1.0.2/ui.min.css
 agent.instance.image=rancher/agent-instance:v0.1.0
 bootstrap.required.image=rancher/agent:v0.3.1
 agent.package.python.agent.url=https://github.com/rancherio/python-agent/releases/download/v0.8.0/python-agent.tar.gz


### PR DESCRIPTION
Fixes a bug in minification that caused the css.url and js.url cookies to get set on every pageload.