### PR TITLE
Add warning message if there are different handlers with the same name

### DIFF
--- a/code/framework/extension/src/main/java/io/cattle/platform/extension/impl/ExtensionManagerImpl.java
+++ b/code/framework/extension/src/main/java/io/cattle/platform/extension/impl/ExtensionManagerImpl.java
@@ -30,8 +30,6 @@ public class ExtensionManagerImpl implements ExtensionManager, InitializationTas
 
     private static final String WILDCARD = "regexp:";
 
-//    private static final Logger log = LoggerFactory.getLogger(ExtensionManagerImpl.class);
-
     Map<String,List<Object>> byKeyRegistry = new HashMap<String, List<Object>>();
     Map<String,ExtensionList<Object>> extensionLists = new HashMap<String, ExtensionList<Object>>();
     Map<String,List<Object>> byName = new HashMap<String, List<Object>>();
@@ -191,7 +189,11 @@ public class ExtensionManagerImpl implements ExtensionManager, InitializationTas
                 }
                 String leftName = objectToName.get(o1);
                 String rightName = objectToName.get(o2);
-                return leftName.compareTo(rightName);
+                int comparisonResult = leftName.compareTo(rightName);
+                if (comparisonResult == 0 && !o1.equals(o2)) {
+                    throw new RuntimeException("Trying to add 2 objects with the same name: " + leftName + ".  Second object is ignored!");
+                }
+                return comparisonResult;
             }
         });
 


### PR DESCRIPTION
@ibuildthecloud 
Add warning message.  I encountered this scenario when I added a new AgentBasedProcessHandler to also handle the host.activate event.  Unfortunately, I also gave it the same name and noticed it wasn't getting executed.  We preserve the list of handlers elsewhere but it disappears when we try to prioritize it in the TreeSet.  Can easily resolve the problem by using different handler names.  But adding this warning in case others accidentally encounter it.