### PR TITLE
LoadBalancer: added more filters

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/lb/LoadBalancerConfigValidationFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/lb/LoadBalancerConfigValidationFilter.java
@@ -1,26 +1,48 @@
 package io.cattle.platform.iaas.api.filter.lb;
 
 import io.cattle.platform.core.constants.LoadBalancerConstants;
+import io.cattle.platform.core.dao.GenericMapDao;
 import io.cattle.platform.core.dao.LoadBalancerDao;
 import io.cattle.platform.core.model.LoadBalancer;
 import io.cattle.platform.core.model.LoadBalancerConfig;
+import io.cattle.platform.core.model.LoadBalancerConfigListenerMap;
+import io.cattle.platform.core.model.LoadBalancerListener;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
+import io.cattle.platform.util.type.CollectionUtils;
 import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
 import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
 
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
 public class LoadBalancerConfigValidationFilter extends AbstractDefaultResourceManagerFilter {
 
+    private static final Map<String, Boolean> actions;
+    static
+    {
+        actions = new HashMap<>();
+        actions.put(LoadBalancerConstants.ACTION_LB_CONFIG_ADD_LISTENER, true);
+        actions.put(LoadBalancerConstants.ACTION_LB_CONFIG_REMOVE_LISTENER, false);
+    }
+
+    @Inject
     LoadBalancerDao lbDao;
+
+    @Inject
+    LoadBalancerFilterUtils lbFilterUtils;
+
+    @Inject
+    GenericMapDao mapDao;
 
     @Override
     public String[] getTypes() {
-        return new String[] { LoadBalancerConstants.OBJECT_LB_CONFIG };
+        return new String[0];
     }
 
     @Override
@@ -38,8 +60,24 @@ public class LoadBalancerConfigValidationFilter extends AbstractDefaultResourceM
         return super.delete(type, id, request, next);
     }
 
-    @Inject
-    public void setLoadBalancerDao(LoadBalancerDao lbDao) {
-        this.lbDao = lbDao;
+    @Override
+    public Object resourceAction(String type, ApiRequest request, ResourceManager next) {
+        if (actions.containsKey(request.getAction())) {
+            Map<String, Object> data = CollectionUtils.toMap(request.getRequestObject());
+            Long listenerId = (Long) data.get(LoadBalancerConstants.FIELD_LB_LISTENER_ID);
+
+            lbFilterUtils.validateGenericMapAction(
+                    mapDao,
+                    LoadBalancerConfigListenerMap.class,
+                    LoadBalancerListener.class,
+                    listenerId,
+                    LoadBalancerConfig.class,
+                    Long.valueOf(request.getId()),
+                    new SimpleEntry<String, Boolean>(LoadBalancerConstants.FIELD_LB_LISTENER_ID, actions.get(request
+                            .getAction())));
+
+        }
+
+        return super.resourceAction(type, request, next);
     }
 }

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/lb/LoadBalancerFilterUtils.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/lb/LoadBalancerFilterUtils.java
@@ -1,0 +1,37 @@
+package io.cattle.platform.iaas.api.filter.lb;
+
+import io.cattle.platform.core.dao.GenericMapDao;
+import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
+
+import java.util.AbstractMap.SimpleEntry;
+
+public class LoadBalancerFilterUtils {
+    /**
+     * 
+     * @param mapType
+     * @param leftResourceType
+     * @param leftResourceId
+     * @param rightResourceType
+     * @param rightResourceId
+     * @param apiField
+     *            - single mapping of API field-to-validate (String) and map action performed (add/remove)
+     */
+    public void validateGenericMapAction(GenericMapDao mapDao, Class<?> mapType, Class<?> leftResourceType,
+            long leftResourceId,
+            Class<?> rightResourceType, long rightResourceId, SimpleEntry<String, Boolean> apiField) {
+
+        if (apiField.getValue().booleanValue()) {
+            if (mapDao.findNonRemoved(mapType, leftResourceType, leftResourceId,
+                    rightResourceType, rightResourceId) != null) {
+                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.NOT_UNIQUE,
+                        apiField.getKey());
+            }
+        } else {
+            if (mapDao.findToRemove(mapType, leftResourceType, leftResourceId,
+                    rightResourceType, rightResourceId) == null) {
+                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_OPTION,
+                        apiField.getKey());
+            }
+        }
+    }
+}

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/lb/LoadBalancerTargetValidationFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/lb/LoadBalancerTargetValidationFilter.java
@@ -1,0 +1,103 @@
+package io.cattle.platform.iaas.api.filter.lb;
+
+import io.cattle.platform.core.constants.LoadBalancerConstants;
+import io.cattle.platform.core.dao.GenericMapDao;
+import io.cattle.platform.core.dao.LoadBalancerTargetDao;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.LoadBalancer;
+import io.cattle.platform.core.model.LoadBalancerTarget;
+import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
+import io.cattle.platform.util.type.CollectionUtils;
+import io.github.ibuildthecloud.gdapi.request.ApiRequest;
+import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
+import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+public class LoadBalancerTargetValidationFilter extends AbstractDefaultResourceManagerFilter {
+    private static final Map<String, Boolean> actions;
+    static
+    {
+        actions = new HashMap<>();
+        actions.put(LoadBalancerConstants.ACTION_LB_ADD_TARGET, true);
+        actions.put(LoadBalancerConstants.ACTION_LB_REMOVE_TARGET, false);
+    }
+
+    @Inject
+    LoadBalancerTargetDao lbTargetDao;
+
+    @Inject
+    LoadBalancerFilterUtils lbFilterUtils;
+
+    @Inject
+    GenericMapDao mapDao;
+
+    @Override
+    public String[] getTypes() {
+        return new String[0];
+    }
+
+    @Override
+    public Class<?>[] getTypeClasses() {
+        return new Class<?>[] { LoadBalancer.class };
+    }
+
+    @Override
+    public Object resourceAction(String type, ApiRequest request, ResourceManager next) {
+        if (actions.containsKey(request.getAction())) {
+            Map<String, Object> data = CollectionUtils.toMap(request.getRequestObject());
+            Long instanceId = (Long) data.get(LoadBalancerConstants.FIELD_LB_TARGET_INSTANCE_ID);
+            String ipAddress = (String) data.get(LoadBalancerConstants.FIELD_LB_TARGET_IPADDRESS);
+
+            boolean isInstance = (instanceId != null);
+            boolean isIp = (ipAddress != null);
+
+            // InstanceId and ipAddress are mutually exclusive; one of them have to be specified
+            if (isInstance == isIp) {
+                if (isInstance) {
+                    ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_OPTION,
+                            LoadBalancerConstants.FIELD_LB_TARGET_IPADDRESS);
+                } else {
+                    ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MISSING_REQUIRED,
+                            LoadBalancerConstants.FIELD_LB_TARGET_INSTANCE_ID);
+                }
+            }
+
+            if (isInstance) {
+                lbFilterUtils.validateGenericMapAction(
+                        mapDao,
+                        LoadBalancerTarget.class,
+                        Instance.class,
+                        instanceId,
+                        LoadBalancer.class,
+                        Long.valueOf(request.getId()),
+                        new SimpleEntry<String, Boolean>(LoadBalancerConstants.FIELD_LB_TARGET_INSTANCE_ID, actions
+                                .get(request
+                                        .getAction())));
+            } else {
+                validateIpMapAction(request, ipAddress);
+            }
+        }
+
+        return super.resourceAction(type, request, next);
+    }
+
+    private void validateIpMapAction(ApiRequest request, String ipAddress) {
+        LoadBalancerTarget target = lbTargetDao.getLbIpAddressTarget(Long.valueOf(request.getId()), ipAddress);
+        if (actions.get(request.getAction())) {
+            if (target != null) {
+                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.NOT_UNIQUE,
+                        LoadBalancerConstants.FIELD_LB_TARGET_IPADDRESS);
+            }
+        } else {
+            if (target == null) {
+                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_OPTION,
+                        LoadBalancerConstants.FIELD_LB_TARGET_IPADDRESS);
+            }
+        }
+    }
+}

--- a/code/iaas/api-logic/src/main/resources/META-INF/cattle/iaas-api/spring-iaas-api-logic-context.xml
+++ b/code/iaas/api-logic/src/main/resources/META-INF/cattle/iaas-api/spring-iaas-api-logic-context.xml
@@ -26,7 +26,8 @@
     <bean class="io.cattle.platform.iaas.api.filter.lb.LoadBalancerListenerValidationFilter" />
     <bean class="io.cattle.platform.iaas.api.filter.lb.LoadBalancerConfigValidationFilter" />
     <bean class="io.cattle.platform.iaas.api.filter.lb.LoadBalancerHostValidationFilter" />
-
+    <bean class="io.cattle.platform.iaas.api.filter.lb.LoadBalancerTargetValidationFilter" />
+    <bean class="io.cattle.platform.iaas.api.filter.lb.LoadBalancerFilterUtils" />
 
     <bean class="io.cattle.platform.iaas.api.object.postinit.AccountFieldPostInitHandler" />
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/LoadBalancerConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/LoadBalancerConstants.java
@@ -20,18 +20,24 @@ public class LoadBalancerConstants {
     public static final String ACTION_ADD_HOST = "addhost";
     public static final String ACTION_REMOVE_HOST = "removehost";
 
+    public static final String ACTION_LB_CONFIG_ADD_LISTENER = "addlistener";
+    public static final String ACTION_LB_CONFIG_REMOVE_LISTENER = "removelistener";
+    public static final String ACTION_LB_ADD_TARGET = "addtarget";
+    public static final String ACTION_LB_REMOVE_TARGET = "removetarget";
+
     public static final String PROCESS_LB_CONFIG_LISTENER_MAP_CREATE = "loadbalancerconfiglistenermap.create";
     public static final String PROCESS_LB_CONFIG_LISTENER_MAP_REMOVE = "loadbalancerconfiglistenermap.remove";
-    public static final String PROCESS_LB_CONFIG_ADD_LISTENER = "loadbalancerconfig.addlistener";
-    public static final String PROCESS_LB_CONFIG_REMOVE_LISTENER = "loadbalancerconfig.removelistener";
-    public static final String PROCESS_LB_CONFIG_SET_LISTENERS = "loadbalancerconfig.setlisteners";
     public static final String PROCESS_LB_CREATE = "loadbalancer.create";
     public static final String PROCESS_LB_UPDATE = "loadbalancer.update";
-    public static final String PROCESS_LB_ADD_TARGET = "loadbalancer.addtarget";
-    public static final String PROCESS_LB_REMOVE_TARGET = "loadbalancer.removetarget";
     public static final String PROCESS_LB_SET_TARGETS = "loadbalancer.settargets";
+    public static final String PROCESS_LB_CONFIG_ADD_LISTENER = "loadbalancerconfig." + ACTION_LB_CONFIG_ADD_LISTENER;
+    public static final String PROCESS_LB_CONFIG_REMOVE_LISTENER = "loadbalancerconfig."
+            + ACTION_LB_CONFIG_REMOVE_LISTENER;
+    public static final String PROCESS_LB_CONFIG_SET_LISTENERS = "loadbalancerconfig.setlisteners";
     public static final String PROCESS_LB_ADD_HOST = "loadbalancer." + ACTION_ADD_HOST;
     public static final String PROCESS_LB_REMOVE_HOST = "loadbalancer." + ACTION_REMOVE_HOST;
+    public static final String PROCESS_LB_ADD_TARGET = "loadbalancer." + ACTION_LB_ADD_TARGET;
+    public static final String PROCESS_LB_REMOVE_TARGET = "loadbalancer." + ACTION_LB_REMOVE_TARGET;
     public static final String PROCESS_LB_TARGET_MAP_CREATE = "loadbalancertarget.create";
     public static final String PROCESS_LB_TARGET_MAP_REMOVE = "loadbalancertarget.remove";
     public static final String PROCESS_LB_LISTENER_REMOVE = "loadbalancerlistener.remove";

--- a/tests/integration/cattletest/core/test_lb.py
+++ b/tests/integration/cattletest/core/test_lb.py
@@ -320,3 +320,87 @@ def test_set_target_instance_and_ip(admin_client, sim_context, config_id):
 
     assert len(target_map) == 1
     assert target_map[0].state == "active"
+
+
+def test_lb_add_target_instance_twice(admin_client, sim_context, config_id):
+    container, lb = create_lb_and_container(admin_client, sim_context,
+                                            config_id)
+
+    # add target to a load balancer
+    lb = lb.addtarget(instanceId=container.id)
+    lb = admin_client.wait_success(lb)
+
+    with pytest.raises(ApiError) as e:
+        lb.addtarget(instanceId=container.id)
+
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'NotUnique'
+    assert e.value.error.fieldName == 'instanceId'
+
+
+def test_lb_remove_non_existing_target_instance(admin_client, sim_context,
+                                                config_id):
+    container, lb = create_lb_and_container(admin_client, sim_context,
+                                            config_id)
+    # remove non-existing target
+    with pytest.raises(ApiError) as e:
+        lb.removetarget(instanceId=container.id)
+
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidOption'
+    assert e.value.error.fieldName == 'instanceId'
+
+
+def test_lb_add_target_ip_address_and_instance(admin_client, sim_context,
+                                               config_id):
+    container, lb = create_lb_and_container(admin_client, sim_context,
+                                            config_id)
+
+    with pytest.raises(ApiError) as e:
+        lb.addtarget(ipAddress="10.1.1.1",
+                     instanceId=container.id)
+
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidOption'
+    assert e.value.error.fieldName == 'ipAddress'
+
+
+def test_lb_add_target_w_no_option(admin_client, sim_context, config_id):
+    container, lb = create_lb_and_container(admin_client, sim_context,
+                                            config_id)
+
+    with pytest.raises(ApiError) as e:
+        lb.addtarget()
+
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'MissingRequired'
+    assert e.value.error.fieldName == 'instanceId'
+
+
+def test_lb_add_target_ip_twice(admin_client, sim_context, config_id):
+    container, lb = create_lb_and_container(admin_client, sim_context,
+                                            config_id)
+
+    # add target to a load balancer
+    lb = lb.addtarget(ipAddress="10.1.1.1")
+    lb = admin_client.wait_success(lb)
+
+    with pytest.raises(ApiError) as e:
+        lb.addtarget(ipAddress="10.1.1.1")
+
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'NotUnique'
+    assert e.value.error.fieldName == 'ipAddress'
+
+
+def test_lb_remove_non_existing_target_ip(admin_client, sim_context,
+                                          config_id):
+    container, lb = create_lb_and_container(admin_client, sim_context,
+                                            config_id)
+    # remove non-existing target
+    with pytest.raises(ApiError) as e:
+        lb.removetarget(ipAddress="10.1.1.1")
+
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidOption'
+    assert e.value.error.fieldName == 'ipAddress'

--- a/tests/integration/cattletest/core/test_lb_config.py
+++ b/tests/integration/cattletest/core/test_lb_config.py
@@ -131,14 +131,14 @@ def test_lb_listener_remove(admin_client, super_client):
     config1 = admin_client. \
         create_loadBalancerConfig(name=random_str())
     config1 = admin_client.wait_success(config1)
-    config1 = config1.\
+    config1 = config1. \
         addlistener(loadBalancerListenerId=listener.id)
     config1 = admin_client.wait_success(config1)
 
     config2 = admin_client. \
         create_loadBalancerConfig(name=random_str())
     config2 = admin_client.wait_success(config2)
-    config2 = config2.\
+    config2 = config2. \
         addlistener(loadBalancerListenerId=listener.id)
     config2 = admin_client.wait_success(config2)
 
@@ -168,14 +168,14 @@ def test_lb_config_remove_w_listeners(admin_client, super_client):
     config1 = admin_client. \
         create_loadBalancerConfig(name=random_str())
     config1 = admin_client.wait_success(config1)
-    config1 = config1.\
+    config1 = config1. \
         addlistener(loadBalancerListenerId=listener.id)
     config1 = admin_client.wait_success(config1)
 
     config2 = admin_client. \
         create_loadBalancerConfig(name=random_str())
     config2 = admin_client.wait_success(config2)
-    config2 = config2.\
+    config2 = config2. \
         addlistener(loadBalancerListenerId=listener.id)
     config2 = admin_client.wait_success(config2)
 
@@ -291,3 +291,31 @@ def _create_config_and_listener(admin_client):
     config = admin_client.create_loadBalancerConfig(name=random_str())
     config = admin_client.wait_success(config)
     return config, listener
+
+
+def test_lb_config_add_listener_twice(admin_client, super_client):
+    config, listener = _create_config_and_listener(admin_client)
+
+    # add listener to the config
+    config = config.addlistener(loadBalancerListenerId=listener.id)
+    config = admin_client.wait_success(config)
+
+    with pytest.raises(ApiError) as e:
+        config.addlistener(loadBalancerListenerId=listener.id)
+
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'NotUnique'
+    assert e.value.error.fieldName == 'loadBalancerListenerId'
+
+
+def test_lb_config_remove_invalid_listener(admin_client, super_client):
+    config, listener = _create_config_and_listener(admin_client)
+
+    # remove non-existing listener
+    with pytest.raises(ApiError) as e:
+        config = config. \
+            removelistener(loadBalancerListenerId=listener.id)
+
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidOption'
+    assert e.value.error.fieldName == 'loadBalancerListenerId'


### PR DESCRIPTION
@ibuildthecloud Darren, this PR adds more filters to LB API actions. 

* filter on add/remove Target action
* filter on add/remove Listener action

Let me know if you think the helper method I've added - "validateGenericMapAction" - should be moved from AbstractDefaultResourceManagerFilter to some *Utils class, and I'll fix it.