### PR TITLE
LB haproxy configuration

### DIFF
--- a/code/iaas/config-item/server/pom.xml
+++ b/code/iaas/config-item/server/pom.xml
@@ -49,5 +49,10 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.cattle</groupId>
+            <artifactId>cattle-iaas-lb-instance</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/LoadBalancerTargetInfo.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/LoadBalancerTargetInfo.java
@@ -1,0 +1,29 @@
+package io.cattle.platform.configitem.context.data;
+
+public class LoadBalancerTargetInfo {
+    private String name;
+    private String ipAddress;
+
+    public LoadBalancerTargetInfo(String ipAddress, String name) {
+        super();
+        this.ipAddress = ipAddress;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+}

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
@@ -1,0 +1,87 @@
+package io.cattle.platform.configitem.context.impl;
+
+import io.cattle.platform.configitem.context.data.LoadBalancerTargetInfo;
+import io.cattle.platform.configitem.server.model.ConfigItem;
+import io.cattle.platform.configitem.server.model.impl.ArchiveContext;
+import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.dao.IpAddressDao;
+import io.cattle.platform.core.dao.LoadBalancerDao;
+import io.cattle.platform.core.model.Agent;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.IpAddress;
+import io.cattle.platform.core.model.LoadBalancer;
+import io.cattle.platform.core.model.LoadBalancerListener;
+import io.cattle.platform.core.model.LoadBalancerTarget;
+import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.lb.instance.service.LoadBalancerInstanceManager;
+import io.cattle.platform.object.ObjectManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+public class LoadBalancerInfoFactory extends AbstractAgentBaseContextFactory {
+
+    @Inject
+    LoadBalancerInstanceManager lbMgr;
+
+    @Inject
+    ObjectManager objectManager;
+
+    @Inject
+    IpAddressDao ipAddressDao;
+
+    @Inject
+    LoadBalancerDao lbDao;
+
+    @Override
+    protected void populateContext(Agent agent, Instance instance, ConfigItem item, ArchiveContext context) {
+        List<? extends LoadBalancerListener> listeners = new ArrayList<>();
+        LoadBalancer lb = lbMgr.getLoadBalancerForInstance(instance);
+        List<LoadBalancerTargetInfo> targetsInfo = new ArrayList<>();
+        if (lb != null) {
+            listeners = lbDao.listActiveListenersForConfig(lb.getLoadBalancerConfigId());
+
+            targetsInfo = populateTargetsInfo(lb);
+        }
+        context.getData().put("listeners", listeners);
+        context.getData().put("publicIp", lbMgr.getLoadBalancerInstanceIp(instance).getAddress());
+        context.getData().put("targets", targetsInfo);
+    }
+
+    private List<LoadBalancerTargetInfo> populateTargetsInfo(LoadBalancer lb) {
+        List<? extends LoadBalancerTarget> targets = objectManager.mappedChildren(
+                objectManager.loadResource(LoadBalancer.class, lb.getId()),
+                LoadBalancerTarget.class);
+        List<LoadBalancerTargetInfo> targetsInfo = new ArrayList<>();
+        for (LoadBalancerTarget target : targets) {
+            if (!(target.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVATING) || target.getState()
+                    .equalsIgnoreCase(CommonStatesConstants.ACTIVE))) {
+                continue;
+            }
+            String ipAddress = target.getIpAddress();
+            if (ipAddress == null) {
+                Instance userInstance = objectManager.loadResource(Instance.class, target.getInstanceId());
+                if (userInstance.getState().equalsIgnoreCase(InstanceConstants.STATE_RUNNING)
+                        || userInstance.getState().equalsIgnoreCase(InstanceConstants.STATE_STARTING)) {
+                    for (Nic nic : objectManager.children(userInstance, Nic.class)) {
+                        IpAddress ip = ipAddressDao.getPrimaryIpAddress(nic);
+                        if (ip != null) {
+                            ipAddress = ip.getAddress();
+                            break;
+                        }
+                    }
+                }
+            }
+            if (ipAddress != null) {
+                String targetName = (target.getName() == null ? target.getUuid() : target.getName());
+                targetsInfo.add(new LoadBalancerTargetInfo(ipAddress, targetName));
+            }
+        }
+        return targetsInfo;
+    }
+}

--- a/code/iaas/config-item/server/src/main/resources/META-INF/cattle/config-server/config-item-defaults.properties
+++ b/code/iaas/config-item/server/src/main/resources/META-INF/cattle/config-server/config-item-defaults.properties
@@ -45,6 +45,8 @@ item.context.metadata.redirect.info.items.extra=
 
 item.context.host.api.key.info.items=host-config
 
+item.context.load.balancer.info.items=haproxy
+
 default.network.domain=compute.localdomain
 default.hostname.prefix=ip-
 

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerRemoveHostPostListener.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerRemoveHostPostListener.java
@@ -16,13 +16,12 @@ import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
 import io.cattle.platform.util.type.CollectionUtils;
 import io.cattle.platform.util.type.Priority;
 
-import java.util.List;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 
 @Named
-public class LoadBalancerRemoveHostPostListener extends AbstractObjectProcessLogic implements ProcessPostListener, Priority {
+public class LoadBalancerRemoveHostPostListener extends AbstractObjectProcessLogic implements ProcessPostListener,
+        Priority {
 
     @Inject
     LoadBalancerInstanceManager lbInstanceManager;
@@ -47,17 +46,16 @@ public class LoadBalancerRemoveHostPostListener extends AbstractObjectProcessLog
     }
 
     protected void removeLoadBalancerInstance(LoadBalancer loadBalancer, long hostId) {
-        List<? extends Instance> lbInstances = lbInstanceManager.createLoadBalancerInstances(loadBalancer, hostId);
-        if (!lbInstances.isEmpty()) {
+        Instance lbInstance = lbInstanceManager.getLoadBalancerInstance(loadBalancer, hostId);
+        if (lbInstance != null) {
             // try to remove first
             try {
-                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, lbInstances.get(0),
+                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, lbInstance,
                         null);
             } catch (ProcessCancelException e) {
-                objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_STOP, lbInstances.get(0),
+                objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_STOP, lbInstance,
                         CollectionUtils.asMap(InstanceConstants.REMOVE_OPTION, true));
             }
         }
     }
-
 }

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/LoadBalancerInstanceManager.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/LoadBalancerInstanceManager.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.lb.instance.service;
 
 import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.IpAddress;
 import io.cattle.platform.core.model.LoadBalancer;
 
 import java.util.List;
@@ -11,4 +12,9 @@ public interface LoadBalancerInstanceManager {
 
     boolean isLbInstance(Instance instance);
 
+    LoadBalancer getLoadBalancerForInstance(Instance lbInstance);
+
+    Instance getLoadBalancerInstance(LoadBalancer loadBalancer, long hostId);
+
+    IpAddress getLoadBalancerInstanceIp(Instance lbInstance);
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -40,6 +40,7 @@ public class InstanceConstants {
 
     public static final String STATE_RUNNING = "running";
     public static final String STATE_STOPPED = "stopped";
+    public static final String STATE_STARTING = "starting";
 
     public static final String ON_STOP_STOP = "stop";
     public static final String ON_STOP_RESTART = "restart";

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/LoadBalancerDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/LoadBalancerDao.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.core.dao;
 
 import io.cattle.platform.core.model.LoadBalancer;
+import io.cattle.platform.core.model.LoadBalancerListener;
 
 import java.util.List;
 
@@ -10,4 +11,5 @@ public interface LoadBalancerDao {
 
     List<? extends LoadBalancer> listByConfigId(long configId);
 
+    List<? extends LoadBalancerListener> listActiveListenersForConfig(long configId);
 }

--- a/resources/content/config-content/haproxy/apply.sh
+++ b/resources/content/config-content/haproxy/apply.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+. ${CATTLE_HOME:-/var/lib/cattle}/common/scripts.sh
+
+stage_files
+
+# enable haproxy
+sed -i -e 's/ENABLED=0/ENABLED=1/g' /etc/default/haproxy
+
+# apply new config
+if haproxy -p /var/run/haproxy.pid -f /etc/haproxy/haproxy.cfg -sf $(cat /var/run/haproxy.pid); then
+    exit 0
+else
+    exit 1
+fi

--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -1,0 +1,47 @@
+global
+	log 127.0.0.1 local0
+    	log 127.0.0.1 local1 notice
+        maxconn 4096
+        maxpipes 1024
+	chroot /var/lib/haproxy
+	user haproxy
+	group haproxy
+	daemon
+
+defaults
+	log	global
+	mode	tcp
+	option	tcplog
+        option  dontlognull
+        option  redispatch
+        option forwardfor
+        option httpclose
+        retries 3
+        contimeout 5000
+        clitimeout 50000
+        srvtimeout 50000
+	errorfile 400 /etc/haproxy/errors/400.http
+	errorfile 403 /etc/haproxy/errors/403.http
+	errorfile 408 /etc/haproxy/errors/408.http
+	errorfile 500 /etc/haproxy/errors/500.http
+	errorfile 502 /etc/haproxy/errors/502.http
+	errorfile 503 /etc/haproxy/errors/503.http
+	errorfile 504 /etc/haproxy/errors/504.http
+
+<#if listeners?has_content && targets?has_content>
+<#list listeners as listener >
+frontend ${listener.name}_frontend
+        bind ${publicIp}:${listener.sourcePort}
+        mode ${listener.sourceProtocol}
+        default_backend ${listener.name}_backend
+
+backend ${listener.name}_backend
+        mode ${listener.targetProtocol}
+        balance ${listener.data.fields.algorithm}
+        <#list targets as target >
+        server ${target.name} ${target.ipAddress}:${listener.targetPort}
+        </#list>
+</#list>
+<#else>
+listen web 0.0.0.0:9
+</#if>

--- a/resources/content/config-content/haproxy/content/etc/monit/conf.d/haproxy
+++ b/resources/content/config-content/haproxy/content/etc/monit/conf.d/haproxy
@@ -1,0 +1,3 @@
+check process haproxy with pidfile /var/run/haproxy.pid
+   start program = "/etc/init.d/haproxy start"
+   stop  program = "/etc/init.d/haproxy stop"

--- a/resources/content/schema/base/addRemoveLoadBalancerTargetInput.json
+++ b/resources/content/schema/base/addRemoveLoadBalancerTargetInput.json
@@ -2,10 +2,12 @@
     "collectionMethods" : [],
     "resourceFields": {
         "instanceId": {
-            "type": "reference[instance]"
+            "type": "reference[instance]",
+            "nullable": true
         },
         "ipAddress": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
         }
     }
 }

--- a/tests/integration/cattletest/core/test_lb_lifecycle.py
+++ b/tests/integration/cattletest/core/test_lb_lifecycle.py
@@ -102,9 +102,9 @@ def _create_lb_w_host(super_client, admin_client, docker_context):
 
 def _create_valid_listener(super_client, admin_client, docker_context):
     listener = admin_client.create_loadBalancerListener(name=random_str(),
-                                                        sourcePort='8080',
+                                                        sourcePort='80',
                                                         targetPort='80',
                                                         sourceProtocol='http',
-                                                        targetProtocol='tcp')
+                                                        targetProtocol='http')
     listener = admin_client.wait_success(listener)
     return listener


### PR DESCRIPTION
@ibuildthecloud Darren, its WIP PR; have a couple of questions:

1) I've realized we don't expose "algorithm" for the local load balancer. Should we just default it to "roundrobin" in haproxy.cfg, or let user specify it.

2) Logging. HA proxy sends its messages to rsyslog, and its not running by default on agent-instance. Do you see any potential downsides if I enable it?

3) There are couple of LB config files that I need to modify before HA proxy starts for the very first time. What would be the right place to invoke the modification: a) DOCKERFILE of agent-instance b) startup.sh script