### PR TITLE
LB: expose algorithm for LBListener

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/lb/LoadBalancerListenerValidationFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/lb/LoadBalancerListenerValidationFilter.java
@@ -25,8 +25,8 @@ public class LoadBalancerListenerValidationFilter extends AbstractDefaultResourc
         if (targetPort == null) {
             long sourcePort = listener.getSourcePort();
             listener.setTargetPort(sourcePort);
-            ;
         }
+
         String targetProtocol = listener.getTargetProtocol();
         if (targetProtocol == null) {
             String sourceProtocol = listener.getSourceProtocol();

--- a/resources/content/schema/base/loadBalancerListener.json
+++ b/resources/content/schema/base/loadBalancerListener.json
@@ -21,7 +21,12 @@
             "type": "int",
             "min": 1,
             "max": 65535
+        },
+        "algorithm": {
+            "type": "enum",
+            "options": [ "roundrobin", "leastconn", "source"],
+            "nullable": true,
+            "default": "roundrobin"
         }
-
     }
 }

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -183,6 +183,7 @@
         "loadBalancerListener.targetPort" : "cr",
         "loadBalancerListener.sourceProtocol" : "cr",
         "loadBalancerListener.targetProtocol" : "cr",
+        "loadBalancerListener.algorithm" : "cr",
 
         "loadBalancerConfig" : "crud",
         "loadBalancerConfig.loadBalancerHealthCheck" : "cr",

--- a/tests/integration/cattletest/core/test_lb_listener.py
+++ b/tests/integration/cattletest/core/test_lb_listener.py
@@ -7,7 +7,8 @@ def test_lb_listener_create(admin_client):
                                                         sourcePort='8080',
                                                         targetPort='80',
                                                         sourceProtocol='http',
-                                                        targetProtocol='tcp')
+                                                        targetProtocol='tcp',
+                                                        algorithm='leastconn')
     listener = admin_client.wait_success(listener)
 
     assert listener.state == 'active'
@@ -15,6 +16,16 @@ def test_lb_listener_create(admin_client):
     assert listener.sourceProtocol == 'http'
     assert listener.targetPort == 80
     assert listener.targetProtocol == 'tcp'
+    assert listener.algorithm == 'leastconn'
+
+
+def test_lb_listener_create_wo_algorithm(admin_client):
+    listener = admin_client.create_loadBalancerListener(name=random_str(),
+                                                        sourcePort='80',
+                                                        sourceProtocol='tcp')
+    listener = admin_client.wait_success(listener)
+
+    assert listener.algorithm == 'roundrobin'
 
 
 def test_lb_listener_protocol_validation(admin_client):


### PR DESCRIPTION
@ibuildthecloud Darren, this PR exposes algorithm on LB listener. Following algorithms are exposed:

roundrobin
leastconn
source
uri
first

There are couple of extras that haproxy supports (static-roundrobin, url-param,rdp-cookie) but I think for v1 it would make sense to expose a limited set of most popular ones. Let me know what you think