### PR TITLE
Ensure ping selects machine

### DIFF
--- a/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/ping/dao/impl/PingDaoImpl.java
+++ b/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/ping/dao/impl/PingDaoImpl.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jooq.Condition;
 import org.jooq.impl.DSL;
 
@@ -131,8 +132,13 @@ public class PingDaoImpl extends AbstractJooqDao implements PingDao {
                         .fetchInto(PhysicalHostRecord.class);
 
         for ( PhysicalHost host : hostList ) {
-            String uuid = DataAccessor.fields(host).withKey(HostConstants.FIELD_REPORTED_UUID).as(String.class);
-            if ( uuid == null ) {
+            String uuid = host.getExternalId();
+            
+            if (StringUtils.isEmpty(uuid)) {
+                uuid = DataAccessor.fields(host).withKey(HostConstants.FIELD_REPORTED_UUID).as(String.class);
+            }
+             
+            if (StringUtils.isEmpty(uuid)) {
                 uuid = host.getUuid();
             }
 

--- a/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/resource/impl/AgentResourcesMonitorImpl.java
+++ b/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/resource/impl/AgentResourcesMonitorImpl.java
@@ -53,10 +53,24 @@ public class AgentResourcesMonitorImpl implements AgentResourcesEventListener {
     ObjectManager objectManager;
     LockDelegator lockDelegator;
     LockManager lockManager;
-    Cache<String,Boolean> resourceCache = CacheBuilder.newBuilder()
-            .expireAfterWrite(CACHE_RESOURCE.get(), TimeUnit.SECONDS)
-            .build();
+    Cache<String,Boolean> resourceCache;
 
+    public AgentResourcesMonitorImpl() {
+        super();
+        buildCache();
+        CACHE_RESOURCE.addCallback(new Runnable() {
+            @Override
+            public void run() {
+                buildCache();
+            }
+        });
+    }
+    
+    protected void buildCache() {
+        resourceCache = CacheBuilder.newBuilder().expireAfterWrite(CACHE_RESOURCE.get(), TimeUnit.SECONDS)
+                .build();
+    }
+    
     @Override
     public void pingReply(Ping ping) {
         String agentIdStr = ping.getResourceId();


### PR DESCRIPTION
Fixes a bug wherein the agent ping logic was replacing the user created
`machine` with a new physical host and assigning it to the host.