### PR TITLE
Machine extracted-config functionality

### DIFF
--- a/code/iaas/api-logic/src/main/resources/META-INF/cattle/api-server/spring-iaas-api-server-context.xml
+++ b/code/iaas/api-logic/src/main/resources/META-INF/cattle/api-server/spring-iaas-api-server-context.xml
@@ -16,6 +16,7 @@
          not properly managed and rely on Spring auto wiring and not the ExtensionManager -->
     <bean class="io.cattle.platform.iaas.api.credential.SshKeyPemDownloadLinkHandler" />
     <bean class="io.cattle.platform.iaas.api.ippool.IpPoolAcquireActionHandler" />
+    <bean class="io.cattle.platform.docker.machine.api.MachineConfigLinkHandler" />
 
     <bean class="io.cattle.platform.iaas.api.cluster.ClusterAddHostActionHandler" />
     <bean class="io.cattle.platform.iaas.api.cluster.ClusterRemoveHostActionHandler" />

--- a/code/implementation/docker/machine/pom.xml
+++ b/code/implementation/docker/machine/pom.xml
@@ -33,5 +33,11 @@
             <artifactId>cattle-iaas-model</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/api/MachineConfigLinkHandler.java
+++ b/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/api/MachineConfigLinkHandler.java
@@ -1,0 +1,51 @@
+package io.cattle.platform.docker.machine.api;
+
+import static io.cattle.platform.docker.machine.constants.MachineConstants.*;
+
+import io.cattle.platform.api.link.LinkHandler;
+import io.cattle.platform.core.model.PhysicalHost;
+import io.cattle.platform.object.util.DataUtils;
+import io.github.ibuildthecloud.gdapi.request.ApiRequest;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
+
+public class MachineConfigLinkHandler implements LinkHandler {
+
+    @Override
+    public String[] getTypes() {
+        return new String[] { MACHINE_KIND };
+    }
+
+    @Override
+    public boolean handles(String type, String id, String link, ApiRequest request) {
+        return CONFIG_LINK.equalsIgnoreCase(link);
+    }
+
+    @Override
+    public Object link(String name, Object obj, ApiRequest request) throws IOException {
+        if ( obj instanceof PhysicalHost ) {
+            PhysicalHost host = (PhysicalHost)obj;
+            String extractedConfig = (String)DataUtils.getFields(host).get(EXTRACTED_CONFIG_FIELD);
+            if ( StringUtils.isNotEmpty(extractedConfig) ) {
+                byte[] content = Base64.decodeBase64(extractedConfig.getBytes());
+                HttpServletResponse response = request.getServletContext().getResponse();
+                response.setContentLength(content.length);
+                response.setContentType("application/x-tar");
+                response.setHeader("Content-Encoding", "gzip");
+                response.setHeader("Content-Disposition", "attachment; filename=" + host.getName() + ".tar.gz");
+                response.setHeader("Cache-Control", "private");
+                response.setHeader("Pragma", "private");
+                response.setHeader("Expires", "Wed 24 Feb 1982 18:42:00 GMT");
+                response.getOutputStream().write(content);
+                return new Object();
+            }
+        }
+
+        return null;
+    }
+}

--- a/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/api/MachineLinkFilter.java
+++ b/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/api/MachineLinkFilter.java
@@ -1,0 +1,37 @@
+package io.cattle.platform.docker.machine.api;
+
+import static io.cattle.platform.docker.machine.constants.MachineConstants.*;
+import io.cattle.platform.core.model.PhysicalHost;
+import io.cattle.platform.object.util.DataUtils;
+import io.github.ibuildthecloud.gdapi.context.ApiContext;
+import io.github.ibuildthecloud.gdapi.model.Resource;
+import io.github.ibuildthecloud.gdapi.request.ApiRequest;
+import io.github.ibuildthecloud.gdapi.response.ResourceOutputFilter;
+
+import org.apache.commons.lang.StringUtils;
+
+public class MachineLinkFilter implements ResourceOutputFilter {
+
+    @Override
+    public Resource filter(ApiRequest request, Object original, Resource converted) {
+        if ( original instanceof PhysicalHost ) {
+            PhysicalHost host = (PhysicalHost)original;
+            if (StringUtils.isNotEmpty((String)DataUtils.getFields(host).get(EXTRACTED_CONFIG_FIELD))) {
+                converted.getLinks().put(CONFIG_LINK, ApiContext.getUrlBuilder().resourceLink(converted, CONFIG_LINK));
+            }
+        }
+
+        return converted;
+    }
+
+    @Override
+    public String[] getTypes() {
+        return new String[] { MACHINE_KIND };
+    }
+
+    @Override
+    public Class<?>[] getTypeClasses() {
+        return new Class<?>[0];
+    }
+
+}

--- a/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/constants/MachineConstants.java
+++ b/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/constants/MachineConstants.java
@@ -5,4 +5,6 @@ public class MachineConstants {
     public static final String MACHINE_KIND = "machine";
     public static final String DRIVER_FIELD = "driver";
     public static final String CONFIG_FIELD_SUFFIX = "Config";
+    public static final String CONFIG_LINK = "config";
+    public static final String EXTRACTED_CONFIG_FIELD = "extractedConfig";
 }

--- a/code/implementation/docker/machine/src/main/resources/META-INF/cattle/docker-machine-api/spring-docker-machine-api-context.xml
+++ b/code/implementation/docker/machine/src/main/resources/META-INF/cattle/docker-machine-api/spring-docker-machine-api-context.xml
@@ -31,4 +31,5 @@
     </bean>
 
     <bean class="io.cattle.platform.docker.machine.api.filter.MachineValidationFilter" />
+    <bean class="io.cattle.platform.docker.machine.api.MachineLinkFilter" />
 </beans>

--- a/code/implementation/docker/machine/src/main/resources/schema/service/service-auth.json.d/machine.json
+++ b/code/implementation/docker/machine/src/main/resources/schema/service/service-auth.json.d/machine.json
@@ -3,7 +3,7 @@
         
         "machine" : "crud",
         "machine.data" : "cru",
-
+        "machine.extractedConfig" : "ru",
 
         "end" : ""
     }

--- a/code/implementation/docker/machine/src/main/resources/schema/user/user-auth.json.d/machine.json
+++ b/code/implementation/docker/machine/src/main/resources/schema/user/user-auth.json.d/machine.json
@@ -5,7 +5,7 @@
         "machine.driver" : "r",
         "machine.authCertificateAuthority" : "cr",
         "machine.authKey" : "cr",
-        "machine.extractedConfig" : "r",
+        "machine.extractedConfig" : "",
         "machine.virtualboxConfig" : "cr",
         "machine.digitaloceanConfig" : "cr",
 

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -516,7 +516,6 @@ def test_machine(admin_client, client, service_client):
         'data': 'r',
         'authCertificateAuthority': 'cr',
         'authKey': 'cr',
-        'extractedConfig': 'r',
         'virtualboxConfig': 'cr',
         'digitaloceanConfig': 'cr',
     })
@@ -527,7 +526,6 @@ def test_machine(admin_client, client, service_client):
         'externalId': 'r',
         'authCertificateAuthority': 'cr',
         'authKey': 'cr',
-        'extractedConfig': 'r',
         'virtualboxConfig': 'cr',
         'digitaloceanConfig': 'cr',
     })
@@ -539,7 +537,7 @@ def test_machine(admin_client, client, service_client):
         'data': 'cru',
         'authCertificateAuthority': 'cr',
         'authKey': 'cr',
-        'extractedConfig': 'r',
+        'extractedConfig': 'ru',
         'virtualboxConfig': 'cr',
         'digitaloceanConfig': 'cr',
     })


### PR DESCRIPTION
Adds the ability for go-machine-service to update machine resources
with a base64 encoded tar file that is the docker-machine's
configuration and the ability for the user to download this
configuration as a tar file from a link on the resource.