### PR TITLE
Work around https://github.com/docker/docker/issues/11087

### DIFF
--- a/resources/content/config-content/bootstrap/bootstrap.sh
+++ b/resources/content/config-content/bootstrap/bootstrap.sh
@@ -65,9 +65,9 @@ download_agent()
 start_agent()
 {
     local main=${CATTLE_HOME}/pyagent/apply.sh
-    export AGENT_PARENT_PID=$$
+    export AGENT_PARENT_PID=$PPID
     info Starting agent $main
-    $main start
+    exec $main start
 }
 
 print_config()


### PR DESCRIPTION
This is a rather simple work around that conviently worked out.  The
python-agent already has code in it such that if its parent process
dies it will terminate itself.  This logic was added to prevent creating
orphan agents in the SSH agent scenario (which is no longer used in
rancher).  By changing the bootstrap script to exec the python agent and
not fork it as a child, this causes the python-agent's parent to be the
container PID.  When the container PID is killed, the python-agent still
has open the FDs from the container PID.  This prevents the container
from properly dying.  But since the python-agent will kill itself when
the container PID dies, the entire container will cleanup.