### PR TITLE
Service Discovery: DNS config item/Json Answer file generation

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ServiceConsumeMapCreateNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ServiceConsumeMapCreateNicLookup.java
@@ -1,0 +1,41 @@
+package io.cattle.platform.agent.instance.service.impl;
+
+import static io.cattle.platform.core.model.tables.NicTable.NIC;
+import io.cattle.platform.agent.instance.service.InstanceNicLookup;
+import io.cattle.platform.core.dao.GenericMapDao;
+import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceConsumeMap;
+import io.cattle.platform.core.model.ServiceExposeMap;
+import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+import io.cattle.platform.object.ObjectManager;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class ServiceConsumeMapCreateNicLookup extends AbstractJooqDao implements InstanceNicLookup {
+    @Inject
+    ObjectManager objectManager;
+
+    @Inject
+    GenericMapDao mapDao;
+
+    @Override
+    public List<? extends Nic> getNics(Object obj) {
+        if (!(obj instanceof ServiceConsumeMap)) {
+            return null;
+        }
+
+        ServiceConsumeMap consumeMap = (ServiceConsumeMap) obj;
+        Service service = objectManager.loadResource(Service.class, consumeMap.getServiceId());
+        
+        List<? extends ServiceExposeMap> exposeMaps = mapDao.findNonRemoved(ServiceExposeMap.class, Service.class,
+                service.getId());
+        if (exposeMaps.isEmpty()) {
+            return null;
+        }
+
+        return create().selectFrom(NIC).where(NIC.INSTANCE_ID.eq(exposeMaps.get(0).getInstanceId())).fetch();
+    }
+}

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ServiceExposeMapCreateNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ServiceExposeMapCreateNicLookup.java
@@ -1,0 +1,29 @@
+package io.cattle.platform.agent.instance.service.impl;
+
+import static io.cattle.platform.core.model.tables.NicTable.NIC;
+import io.cattle.platform.agent.instance.service.InstanceNicLookup;
+import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.core.model.ServiceExposeMap;
+import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+import io.cattle.platform.object.ObjectManager;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class ServiceExposeMapCreateNicLookup extends AbstractJooqDao implements InstanceNicLookup {
+
+    @Inject
+    ObjectManager objectManager;
+
+    @Override
+    public List<? extends Nic> getNics(Object obj) {
+        if (!(obj instanceof ServiceExposeMap)) {
+            return null;
+        }
+
+        ServiceExposeMap map = (ServiceExposeMap) obj;
+        return create().selectFrom(NIC).where(NIC.INSTANCE_ID.eq(map.getInstanceId())).fetch();
+    }
+
+}

--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
@@ -44,3 +44,8 @@ host.instancehostmap.deactivate.agentInstanceProvider.hostNatGatewayService.incr
 
 host.ipassociation.activate.agentInstanceProvider.hostNatGatewayService.increment=host-routes,host-iptables
 host.ipassociation.deactivate.agentInstanceProvider.hostNatGatewayService.increment=host-routes,host-iptables
+
+instancelink.update.agentInstanceProvider.dnsService.apply=dns
+instancelink.update.agentInstanceProvider.dnsService.increment=dns
+instancelink.activate.agentInstanceProvider.dnsService.apply=dns
+instancelink.activate.agentInstanceProvider.dnsService.increment=dns

--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
@@ -9,7 +9,7 @@ agent.instance.start.items.increment.extra=
 agent.instance.services.base.items=${agent.instance.start.items.apply},${agent.instance.start.items.increment},${agent.instance.services.base.items.extra}
 agent.instance.services.base.items.extra=
 
-agent.instance.services.processes=nic.activate,instancelink.update,instancelink.activate,hostipaddressmap.activate,${agent.instance.services.processes.extra}
+agent.instance.services.processes=nic.activate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,${agent.instance.services.processes.extra}
 agent.instance.services.processes.extra=
 
 nic.activate.agentInstanceProvider.base.items=true
@@ -45,7 +45,7 @@ host.instancehostmap.deactivate.agentInstanceProvider.hostNatGatewayService.incr
 host.ipassociation.activate.agentInstanceProvider.hostNatGatewayService.increment=host-routes,host-iptables
 host.ipassociation.deactivate.agentInstanceProvider.hostNatGatewayService.increment=host-routes,host-iptables
 
-instancelink.update.agentInstanceProvider.dnsService.apply=dns
-instancelink.update.agentInstanceProvider.dnsService.increment=dns
-instancelink.activate.agentInstanceProvider.dnsService.apply=dns
-instancelink.activate.agentInstanceProvider.dnsService.increment=dns
+serviceconsumemap.create.agentInstanceProvider.dnsService.apply=dns
+serviceconsumemap.create.agentInstanceProvider.dnsService.increment=dns
+serviceexposemap.create.agentInstanceProvider.dnsService.apply=dns
+serviceexposemap.create.agentInstanceProvider.dnsService.increment=dns

--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/spring-agent-instance-context.xml
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/spring-agent-instance-context.xml
@@ -24,6 +24,8 @@
     <bean class="io.cattle.platform.agent.instance.service.impl.HostIpAddressMapNicLookup" />
     <bean class="io.cattle.platform.agent.instance.service.impl.PortNicLookup" />
     <bean class="io.cattle.platform.agent.instance.service.impl.IpAssociationNicLookup" />
+    <bean class="io.cattle.platform.agent.instance.service.impl.ServiceExposeMapCreateNicLookup" />
+    <bean class="io.cattle.platform.agent.instance.service.impl.ServiceConsumeMapCreateNicLookup" />
 
     <bean id="AgentInstanceTypes" class="io.cattle.platform.object.meta.TypeSet" >
         <property name="typeNames">

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
@@ -1,0 +1,10 @@
+package io.cattle.platform.configitem.context.dao;
+
+import io.cattle.platform.configitem.context.data.DnsEntryData;
+import io.cattle.platform.core.model.Instance;
+
+import java.util.List;
+
+public interface DnsInfoDao {
+    List<DnsEntryData> getHostDnsData(Instance instance);
+}

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
@@ -6,5 +6,9 @@ import io.cattle.platform.core.model.Instance;
 import java.util.List;
 
 public interface DnsInfoDao {
-    List<DnsEntryData> getHostDnsData(Instance instance);
+    List<DnsEntryData> getInstanceLinksHostDnsData(Instance instance);
+
+    List<DnsEntryData> getServiceHostDnsData(Instance instance);
+
+    List<DnsEntryData> getSelfServiceLinks(Instance instance);
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
@@ -4,18 +4,23 @@ import static io.cattle.platform.core.model.tables.InstanceLinkTable.INSTANCE_LI
 import static io.cattle.platform.core.model.tables.IpAddressNicMapTable.IP_ADDRESS_NIC_MAP;
 import static io.cattle.platform.core.model.tables.IpAddressTable.IP_ADDRESS;
 import static io.cattle.platform.core.model.tables.NicTable.NIC;
+import static io.cattle.platform.core.model.tables.ServiceConsumeMapTable.SERVICE_CONSUME_MAP;
+import static io.cattle.platform.core.model.tables.ServiceExposeMapTable.SERVICE_EXPOSE_MAP;
+import static io.cattle.platform.core.model.tables.ServiceTable.SERVICE;
 import io.cattle.platform.configitem.context.dao.DnsInfoDao;
 import io.cattle.platform.configitem.context.data.DnsEntryData;
 import io.cattle.platform.core.constants.IpAddressConstants;
-import io.cattle.platform.core.dao.IpAddressDao;
-import io.cattle.platform.core.dao.NicDao;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.InstanceLink;
 import io.cattle.platform.core.model.IpAddress;
+import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.tables.InstanceLinkTable;
 import io.cattle.platform.core.model.tables.IpAddressNicMapTable;
 import io.cattle.platform.core.model.tables.IpAddressTable;
 import io.cattle.platform.core.model.tables.NicTable;
+import io.cattle.platform.core.model.tables.ServiceConsumeMapTable;
+import io.cattle.platform.core.model.tables.ServiceExposeMapTable;
+import io.cattle.platform.core.model.tables.ServiceTable;
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.db.jooq.mapper.MultiRecordMapper;
 
@@ -24,19 +29,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.inject.Inject;
-
 public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
 
     @Override
-    public List<DnsEntryData> getHostDnsData(Instance instance) {
+    public List<DnsEntryData> getInstanceLinksHostDnsData(final Instance instance) {
         MultiRecordMapper<DnsEntryData> mapper = new MultiRecordMapper<DnsEntryData>() {
             @Override
             protected DnsEntryData map(List<Object> input) {
                 DnsEntryData data = new DnsEntryData();
-                Map<String, List<? extends IpAddress>> resolve = new HashMap<>();
+                Map<String, List<IpAddress>> resolve = new HashMap<>();
                 List<IpAddress> ips = new ArrayList<>();
                 ips.add((IpAddress) input.get(1));
+                // add all instance links
                 resolve.put(((InstanceLink) input.get(0)).getLinkName(), ips);
                 data.setSourceIpAddress((IpAddress) input.get(2));
                 data.setResolve(resolve);
@@ -80,6 +84,135 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
                         .and(clientNic.REMOVED.isNull())
                         .and(targetNic.REMOVED.isNull())
                         .and(instanceLink.REMOVED.isNull()))
+                .fetch().map(mapper);
+    }
+
+    @Override
+    public List<DnsEntryData> getServiceHostDnsData(final Instance instance) {
+        MultiRecordMapper<DnsEntryData> mapper = new MultiRecordMapper<DnsEntryData>() {
+            @Override
+            protected DnsEntryData map(List<Object> input) {
+                DnsEntryData data = new DnsEntryData();
+                Map<String, List<IpAddress>> resolve = new HashMap<>();
+                List<IpAddress> ips = new ArrayList<>();
+                ips.add((IpAddress) input.get(1));
+                resolve.put(((Service) input.get(0)).getName(), ips);
+                data.setSourceIpAddress((IpAddress) input.get(2));
+                data.setResolve(resolve);
+                return data;
+            }
+        };
+
+        ServiceTable targetService = mapper.add(SERVICE);
+        IpAddressTable targetIpAddress = mapper.add(IP_ADDRESS);
+        IpAddressTable clientIpAddress = mapper.add(IP_ADDRESS);
+        NicTable clientNic = NIC.as("client_nic");
+        NicTable targetNic = NIC.as("target_nic");
+        IpAddressNicMapTable clientNicIpTable = IP_ADDRESS_NIC_MAP.as("client_nic_ip");
+        IpAddressNicMapTable targetNicIpTable = IP_ADDRESS_NIC_MAP.as("target_nic_ip");
+        ServiceExposeMapTable clientServiceExposeMap = SERVICE_EXPOSE_MAP.as("service_expose_map_client");
+        ServiceExposeMapTable targetServiceExposeMap = SERVICE_EXPOSE_MAP.as("service_expose_map_target");
+        ServiceConsumeMapTable serviceConsumeMap = SERVICE_CONSUME_MAP.as("service_consume_map");
+
+        return create()
+                .select(mapper.fields())
+                .from(NIC)
+                .join(clientNic)
+                .on(NIC.VNET_ID.eq(clientNic.VNET_ID))
+                .join(clientServiceExposeMap)
+                .on(clientServiceExposeMap.INSTANCE_ID.eq(clientNic.INSTANCE_ID))
+                .join(serviceConsumeMap)
+                .on(serviceConsumeMap.SERVICE_ID.eq(clientServiceExposeMap.SERVICE_ID))
+                .join(targetServiceExposeMap)
+                .on(targetServiceExposeMap.SERVICE_ID.eq(serviceConsumeMap.CONSUMED_SERVICE_ID))
+                .join(targetService)
+                .on(serviceConsumeMap.CONSUMED_SERVICE_ID.eq(targetService.ID))
+                .join(targetNic)
+                .on(targetNic.INSTANCE_ID.eq(targetServiceExposeMap.INSTANCE_ID))
+                .join(targetNicIpTable)
+                .on(targetNicIpTable.NIC_ID.eq(targetNic.ID))
+                .join(targetIpAddress)
+                .on(targetNicIpTable.IP_ADDRESS_ID.eq(targetIpAddress.ID))
+                .join(clientNicIpTable)
+                .on(clientNicIpTable.NIC_ID.eq(clientNic.ID))
+                .join(clientIpAddress)
+                .on(clientNicIpTable.IP_ADDRESS_ID.eq(clientIpAddress.ID))
+                .where(NIC.INSTANCE_ID.eq(instance.getId())
+                        .and(NIC.VNET_ID.isNotNull())
+                        .and(NIC.REMOVED.isNull())
+                        .and(targetIpAddress.ROLE.eq(IpAddressConstants.ROLE_PRIMARY))
+                        .and(targetIpAddress.REMOVED.isNull())
+                        .and(clientIpAddress.ROLE.eq(IpAddressConstants.ROLE_PRIMARY))
+                        .and(clientIpAddress.REMOVED.isNull())
+                        .and(targetNicIpTable.REMOVED.isNull())
+                        .and(clientNic.REMOVED.isNull())
+                        .and(targetNic.REMOVED.isNull())
+                        .and(serviceConsumeMap.REMOVED.isNull())
+                        .and(clientServiceExposeMap.REMOVED.isNull())
+                        .and(targetServiceExposeMap.REMOVED.isNull())
+                        .and(targetService.REMOVED.isNull()))
+                .fetch().map(mapper);
+    }
+
+    @Override
+    public List<DnsEntryData> getSelfServiceLinks(Instance instance) {
+        MultiRecordMapper<DnsEntryData> mapper = new MultiRecordMapper<DnsEntryData>() {
+            @Override
+            protected DnsEntryData map(List<Object> input) {
+                DnsEntryData data = new DnsEntryData();
+                Map<String, List<IpAddress>> resolve = new HashMap<>();
+                List<IpAddress> ips = new ArrayList<>();
+                ips.add((IpAddress) input.get(1));
+                resolve.put(((Service) input.get(0)).getName(), ips);
+                data.setSourceIpAddress((IpAddress) input.get(2));
+                data.setResolve(resolve);
+                return data;
+            }
+        };
+
+        ServiceTable targetService = mapper.add(SERVICE);
+        IpAddressTable targetIpAddress = mapper.add(IP_ADDRESS);
+        IpAddressTable clientIpAddress = mapper.add(IP_ADDRESS);
+        NicTable clientNic = NIC.as("client_nic");
+        NicTable targetNic = NIC.as("target_nic");
+        IpAddressNicMapTable clientNicIpTable = IP_ADDRESS_NIC_MAP.as("client_nic_ip");
+        IpAddressNicMapTable targetNicIpTable = IP_ADDRESS_NIC_MAP.as("target_nic_ip");
+        ServiceExposeMapTable clientServiceExposeMap = SERVICE_EXPOSE_MAP.as("service_expose_map_client");
+        ServiceExposeMapTable targetServiceExposeMap = SERVICE_EXPOSE_MAP.as("service_expose_map_target");
+
+        return create()
+                .select(mapper.fields())
+                .from(NIC)
+                .join(clientNic)
+                .on(NIC.VNET_ID.eq(clientNic.VNET_ID))
+                .join(clientServiceExposeMap)
+                .on(clientServiceExposeMap.INSTANCE_ID.eq(clientNic.INSTANCE_ID))
+                .join(targetService)
+                .on(targetService.ID.eq(clientServiceExposeMap.SERVICE_ID))
+                .join(targetServiceExposeMap)
+                .on(targetServiceExposeMap.SERVICE_ID.eq(targetService.ID))
+                .join(targetNic)
+                .on(targetNic.INSTANCE_ID.eq(targetServiceExposeMap.INSTANCE_ID))
+                .join(targetNicIpTable)
+                .on(targetNicIpTable.NIC_ID.eq(targetNic.ID))
+                .join(targetIpAddress)
+                .on(targetNicIpTable.IP_ADDRESS_ID.eq(targetIpAddress.ID))
+                .join(clientNicIpTable)
+                .on(clientNicIpTable.NIC_ID.eq(clientNic.ID))
+                .join(clientIpAddress)
+                .on(clientNicIpTable.IP_ADDRESS_ID.eq(clientIpAddress.ID))
+                .where(NIC.INSTANCE_ID.eq(instance.getId())
+                        .and(NIC.VNET_ID.isNotNull())
+                        .and(NIC.REMOVED.isNull())
+                        .and(targetIpAddress.ROLE.eq(IpAddressConstants.ROLE_PRIMARY))
+                        .and(targetIpAddress.REMOVED.isNull())
+                        .and(clientIpAddress.ROLE.eq(IpAddressConstants.ROLE_PRIMARY))
+                        .and(clientIpAddress.REMOVED.isNull())
+                        .and(targetNicIpTable.REMOVED.isNull())
+                        .and(clientNic.REMOVED.isNull())
+                        .and(targetNic.REMOVED.isNull())
+                        .and(clientServiceExposeMap.REMOVED.isNull())
+                        .and(targetServiceExposeMap.REMOVED.isNull()))
                 .fetch().map(mapper);
     }
 

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
@@ -1,0 +1,86 @@
+package io.cattle.platform.configitem.context.dao.impl;
+
+import static io.cattle.platform.core.model.tables.InstanceLinkTable.INSTANCE_LINK;
+import static io.cattle.platform.core.model.tables.IpAddressNicMapTable.IP_ADDRESS_NIC_MAP;
+import static io.cattle.platform.core.model.tables.IpAddressTable.IP_ADDRESS;
+import static io.cattle.platform.core.model.tables.NicTable.NIC;
+import io.cattle.platform.configitem.context.dao.DnsInfoDao;
+import io.cattle.platform.configitem.context.data.DnsEntryData;
+import io.cattle.platform.core.constants.IpAddressConstants;
+import io.cattle.platform.core.dao.IpAddressDao;
+import io.cattle.platform.core.dao.NicDao;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.InstanceLink;
+import io.cattle.platform.core.model.IpAddress;
+import io.cattle.platform.core.model.tables.InstanceLinkTable;
+import io.cattle.platform.core.model.tables.IpAddressNicMapTable;
+import io.cattle.platform.core.model.tables.IpAddressTable;
+import io.cattle.platform.core.model.tables.NicTable;
+import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+import io.cattle.platform.db.jooq.mapper.MultiRecordMapper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
+
+    @Override
+    public List<DnsEntryData> getHostDnsData(Instance instance) {
+        MultiRecordMapper<DnsEntryData> mapper = new MultiRecordMapper<DnsEntryData>() {
+            @Override
+            protected DnsEntryData map(List<Object> input) {
+                DnsEntryData data = new DnsEntryData();
+                Map<String, List<? extends IpAddress>> resolve = new HashMap<>();
+                List<IpAddress> ips = new ArrayList<>();
+                ips.add((IpAddress) input.get(1));
+                resolve.put(((InstanceLink) input.get(0)).getLinkName(), ips);
+                data.setSourceIpAddress((IpAddress) input.get(2));
+                data.setResolve(resolve);
+                return data;
+            }
+        };
+
+        InstanceLinkTable instanceLink = mapper.add(INSTANCE_LINK);
+        IpAddressTable targetIpAddress = mapper.add(IP_ADDRESS);
+        IpAddressTable clientIpAddress = mapper.add(IP_ADDRESS);
+        NicTable clientNic = NIC.as("client_nic");
+        NicTable targetNic = NIC.as("target_nic");
+        IpAddressNicMapTable clientNicIpTable = IP_ADDRESS_NIC_MAP.as("client_nic_ip");
+        IpAddressNicMapTable targetNicIpTable = IP_ADDRESS_NIC_MAP.as("target_nic_ip");
+
+        return create()
+                .select(mapper.fields())
+                .from(NIC)
+                .join(clientNic)
+                .on(NIC.VNET_ID.eq(clientNic.VNET_ID))
+                .join(instanceLink)
+                .on(instanceLink.INSTANCE_ID.eq(clientNic.INSTANCE_ID))
+                .join(targetNic)
+                .on(targetNic.INSTANCE_ID.eq(instanceLink.TARGET_INSTANCE_ID))
+                .join(targetNicIpTable)
+                .on(targetNicIpTable.NIC_ID.eq(targetNic.ID))
+                .join(targetIpAddress)
+                .on(targetNicIpTable.IP_ADDRESS_ID.eq(targetIpAddress.ID))
+                .join(clientNicIpTable)
+                .on(clientNicIpTable.NIC_ID.eq(clientNic.ID))
+                .join(clientIpAddress)
+                .on(clientNicIpTable.IP_ADDRESS_ID.eq(clientIpAddress.ID))
+                .where(NIC.INSTANCE_ID.eq(instance.getId())
+                        .and(NIC.VNET_ID.isNotNull())
+                        .and(NIC.REMOVED.isNull())
+                        .and(targetIpAddress.ROLE.eq(IpAddressConstants.ROLE_PRIMARY))
+                        .and(targetIpAddress.REMOVED.isNull())
+                        .and(clientIpAddress.ROLE.eq(IpAddressConstants.ROLE_PRIMARY))
+                        .and(clientIpAddress.REMOVED.isNull())
+                        .and(targetNicIpTable.REMOVED.isNull())
+                        .and(clientNic.REMOVED.isNull())
+                        .and(targetNic.REMOVED.isNull())
+                        .and(instanceLink.REMOVED.isNull()))
+                .fetch().map(mapper);
+    }
+
+}

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/DnsEntryData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/DnsEntryData.java
@@ -8,10 +8,9 @@ import java.util.Map;
 
 public class DnsEntryData {
     IpAddress sourceIpAddress;
-    Map<String, List<? extends IpAddress>> resolve = new HashMap<>();
+    Map<String, List<IpAddress>> resolve = new HashMap<>();
 
     public DnsEntryData() {
-
     }
 
     public IpAddress getSourceIpAddress() {
@@ -23,11 +22,11 @@ public class DnsEntryData {
     }
 
 
-    public Map<String, List<? extends IpAddress>> getResolve() {
+    public Map<String, List<IpAddress>> getResolve() {
         return resolve;
     }
 
-    public void setResolve(Map<String, List<? extends IpAddress>> resolve) {
+    public void setResolve(Map<String, List<IpAddress>> resolve) {
         this.resolve = resolve;
     }
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/DnsEntryData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/DnsEntryData.java
@@ -1,0 +1,33 @@
+package io.cattle.platform.configitem.context.data;
+
+import io.cattle.platform.core.model.IpAddress;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DnsEntryData {
+    IpAddress sourceIpAddress;
+    Map<String, List<? extends IpAddress>> resolve = new HashMap<>();
+
+    public DnsEntryData() {
+
+    }
+
+    public IpAddress getSourceIpAddress() {
+        return sourceIpAddress;
+    }
+
+    public void setSourceIpAddress(IpAddress sourceIpAddress) {
+        this.sourceIpAddress = sourceIpAddress;
+    }
+
+
+    public Map<String, List<? extends IpAddress>> getResolve() {
+        return resolve;
+    }
+
+    public void setResolve(Map<String, List<? extends IpAddress>> resolve) {
+        this.resolve = resolve;
+    }
+}

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/DnsInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/DnsInfoFactory.java
@@ -1,0 +1,44 @@
+package io.cattle.platform.configitem.context.impl;
+
+import io.cattle.platform.configitem.context.dao.DnsInfoDao;
+import io.cattle.platform.configitem.context.data.DnsEntryData;
+import io.cattle.platform.configitem.server.model.ConfigItem;
+import io.cattle.platform.configitem.server.model.impl.ArchiveContext;
+import io.cattle.platform.core.model.Agent;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.IpAddress;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+public class DnsInfoFactory extends AbstractAgentBaseContextFactory {
+    @Inject
+    DnsInfoDao dnsInfoDao;
+
+    @Override
+    protected void populateContext(Agent agent, Instance instance, ConfigItem item, ArchiveContext context) {
+        // 1. retrieve all the links for the hosts
+        List<? extends DnsEntryData> dnsEntries = dnsInfoDao.getHostDnsData(instance);
+        // 2. aggregate the links based on the source ip address
+        Map<String, DnsEntryData> processedDnsEntries = new HashMap<>();
+        for (DnsEntryData dnsEntry : dnsEntries) {
+            Map<String, List<? extends IpAddress>> resolve = new HashMap<>();
+            DnsEntryData existingData = null;
+            if (processedDnsEntries.containsKey(dnsEntry.getSourceIpAddress().getAddress())) {
+                existingData = processedDnsEntries.get(dnsEntry.getSourceIpAddress().getAddress());
+                resolve = existingData.getResolve();
+                resolve.putAll(dnsEntry.getResolve());
+            } else {
+                existingData = dnsEntry;
+            }
+
+            processedDnsEntries.put(dnsEntry.getSourceIpAddress().getAddress(), existingData);
+        }
+        context.getData().put("dnsEntries", processedDnsEntries.values());
+    }
+}

--- a/code/iaas/config-item/server/src/main/resources/META-INF/cattle/config-server/config-item-defaults.properties
+++ b/code/iaas/config-item/server/src/main/resources/META-INF/cattle/config-server/config-item-defaults.properties
@@ -49,6 +49,8 @@ item.context.load.balancer.info.items=haproxy
 
 item.context.cluster.info.items=cluster
 
+item.context.dns.info.items=dns
+
 default.network.domain=compute.localdomain
 default.hostname.prefix=ip-
 

--- a/code/iaas/config-item/server/src/main/resources/META-INF/cattle/config-server/spring-config-item-server-context.xml
+++ b/code/iaas/config-item/server/src/main/resources/META-INF/cattle/config-server/spring-config-item-server-context.xml
@@ -14,6 +14,7 @@
         http://cattle.io/schemas/spring/extension http://cattle.io/schemas/spring/extension-1.0.xsd">
 
     <bean class="io.cattle.platform.configitem.context.dao.impl.NetworkInfoDaoImpl" />
+    <bean class="io.cattle.platform.configitem.context.dao.impl.DnsInfoDaoImpl" />
 
     <bean class="io.cattle.platform.configitem.server.impl.ConfigItemServerImpl" />
     <bean class="io.cattle.platform.configitem.registry.impl.ConfigItemRegistryImpl" >

--- a/resources/content/config-content/dns/apply.sh
+++ b/resources/content/config-content/dns/apply.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. ${CATTLE_HOME:-/var/lib/cattle}/common/scripts.sh
+
+stage_files
+
+# TODO - implement startup up dns server
+exit 0

--- a/resources/content/config-content/dns/content/etc/dns/answers.json.ftl
+++ b/resources/content/config-content/dns/content/etc/dns/answers.json.ftl
@@ -1,0 +1,19 @@
+{
+    "default": {
+        "recurse": ["8.8.8.8"],
+        "rancher.com.": ["1.2.3.4"]
+    },
+<#if dnsEntries?? && dnsEntries?has_content>
+    <#list dnsEntries as dnsEntry>
+        <#if dnsEntry.resolve?has_content>
+    "${dnsEntry.sourceIpAddress.address}": {
+                <#list dnsEntry.resolve?keys as dnsName>
+                  <#if dnsEntry.resolve[dnsName]?? && dnsEntry.resolve[dnsName]?has_content>
+        "${dnsName}.": [<#list dnsEntry.resolve[dnsName] as address>"${address.address}"<#if address_has_next>, </#if></#list>]<#if dnsName_has_next>,</#if>
+                    </#if>
+                </#list>
+    }<#if dnsEntry_has_next>, </#if>
+        </#if>
+</#list>
+</#if>
+}


### PR DESCRIPTION
@ibuildthecloud Darren, this PR introduces new config item - "dns" - and the logic for this config item update / dns answers.json file generation. The config file ends up on the network-agent instance. The file doesn't get applied, and there dns service is not installed on the network-agent. 

What goes to answers.json file:

* data generated based on instance links for service's instances
* data generated based on consumed services for service's instances
* for every instance of service "foo", dns records containing ips of all other instances of service "foo"

DNS data gets generated just for the containers that participate in the Service Discovery service. Regular instances are not affected.