### PR TITLE
Add flag to enable bootstrap on run

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -3,6 +3,13 @@ set -e
 
 cd $(dirname $0)/..
 
+# This will start MySQL if needed.
+if [ "${BOOTSTRAP_ON_RUN}" = "true" ]; then
+    ./scripts/bootstrap
+    trap "service mysql stop" EXIT SIGTERM
+fi
+
+
 RUNTIME_DIR=${RUNTIME_DIR:-../../../runtime/cli/}
 
 cd code/packaging/app


### PR DESCRIPTION
In the latest environment we need the ability to run MySQL with the run command. Also, if we exit the trap will attempt to shut down MySQL cleanly.