### PR TITLE
Error handling framework for ExternalHandlers

### DIFF
--- a/code/iaas/external-handler/src/main/java/io/cattle/platform/extension/dynamic/api/addon/ExternalHandlerProcessConfig.java
+++ b/code/iaas/external-handler/src/main/java/io/cattle/platform/extension/dynamic/api/addon/ExternalHandlerProcessConfig.java
@@ -1,0 +1,25 @@
+package io.cattle.platform.extension.dynamic.api.addon;
+
+import io.github.ibuildthecloud.gdapi.annotation.Type;
+
+@Type(list = false)
+public class ExternalHandlerProcessConfig {
+    String name;
+    String onError;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getOnError() {
+        return onError;
+    }
+
+    public void setOnError(String onError) {
+        this.onError = onError;
+    }
+}

--- a/code/iaas/external-handler/src/main/java/io/cattle/platform/extension/dynamic/dao/ExternalHandlerDao.java
+++ b/code/iaas/external-handler/src/main/java/io/cattle/platform/extension/dynamic/dao/ExternalHandlerDao.java
@@ -1,11 +1,13 @@
 package io.cattle.platform.extension.dynamic.dao;
 
 import io.cattle.platform.core.model.ExternalHandler;
+import io.cattle.platform.extension.dynamic.data.ExternalHandlerData;
 
 import java.util.List;
 
 public interface ExternalHandlerDao {
 
-    List<? extends ExternalHandler> getExternalHandler(String eventName);
+    List<? extends ExternalHandler> getExternalHandler(String processName);
+    List<? extends ExternalHandlerData> getExternalHandlerData(String processName);
 
 }

--- a/code/iaas/external-handler/src/main/java/io/cattle/platform/extension/dynamic/dao/impl/ExternalHandlerDaoImpl.java
+++ b/code/iaas/external-handler/src/main/java/io/cattle/platform/extension/dynamic/dao/impl/ExternalHandlerDaoImpl.java
@@ -1,15 +1,21 @@
 package io.cattle.platform.extension.dynamic.dao.impl;
 
-import java.util.List;
-
+import static io.cattle.platform.core.model.tables.ExternalHandlerExternalHandlerProcessMapTable.EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP;
+import static io.cattle.platform.core.model.tables.ExternalHandlerProcessTable.EXTERNAL_HANDLER_PROCESS;
+import static io.cattle.platform.core.model.tables.ExternalHandlerTable.EXTERNAL_HANDLER;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.model.ExternalHandler;
 import io.cattle.platform.core.model.tables.records.ExternalHandlerRecord;
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.extension.dynamic.dao.ExternalHandlerDao;
-import static io.cattle.platform.core.model.tables.ExternalHandlerProcessTable.*;
-import static io.cattle.platform.core.model.tables.ExternalHandlerTable.*;
-import static io.cattle.platform.core.model.tables.ExternalHandlerExternalHandlerProcessMapTable.*;
+import io.cattle.platform.extension.dynamic.data.ExternalHandlerData;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jooq.Field;
+import org.jooq.Result;
 
 public class ExternalHandlerDaoImpl extends AbstractJooqDao implements ExternalHandlerDao {
 
@@ -28,6 +34,25 @@ public class ExternalHandlerDaoImpl extends AbstractJooqDao implements ExternalH
                         .and(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP.STATE.eq(CommonStatesConstants.ACTIVE))
                         .and(EXTERNAL_HANDLER_PROCESS.STATE.eq(CommonStatesConstants.ACTIVE)))
                 .fetchInto(ExternalHandlerRecord.class);
+    }
+    
+    public List<? extends ExternalHandlerData> getExternalHandlerData(String processName) {
+    	List<Field<?>> fields = new ArrayList<Field<?>>(Arrays.asList(EXTERNAL_HANDLER.fields()));
+    	fields.add(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP.ON_ERROR);
+    	 	
+        return create()
+                .select(fields)
+                .from(EXTERNAL_HANDLER)
+                .join(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP)
+                    .on(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP.EXTERNAL_HANDLER_ID.eq(EXTERNAL_HANDLER.ID))
+                .join(EXTERNAL_HANDLER_PROCESS)
+                    .on(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP.EXTERNAL_HANDLER_PROCESS_ID.eq(EXTERNAL_HANDLER_PROCESS.ID))
+                .where(
+                        EXTERNAL_HANDLER_PROCESS.NAME.eq(processName)
+                        .and(EXTERNAL_HANDLER.STATE.eq(CommonStatesConstants.ACTIVE))
+                        .and(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP.STATE.eq(CommonStatesConstants.ACTIVE))
+                        .and(EXTERNAL_HANDLER_PROCESS.STATE.eq(CommonStatesConstants.ACTIVE)))
+                .fetchInto(ExternalHandlerData.class);
     }
 
 }

--- a/code/iaas/external-handler/src/main/java/io/cattle/platform/extension/dynamic/data/ExternalHandlerData.java
+++ b/code/iaas/external-handler/src/main/java/io/cattle/platform/extension/dynamic/data/ExternalHandlerData.java
@@ -1,0 +1,69 @@
+package io.cattle.platform.extension.dynamic.data;
+
+
+public class ExternalHandlerData {
+
+    String name;
+    Integer priority;
+    String onError;
+    Integer retries;
+    Long timeout;
+    String priorityName;
+    java.util.Map<String, Object> data;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Integer priority) {
+        this.priority = priority;
+    }
+
+    public String getOnError() {
+        return onError;
+    }
+
+    public void setOnError(String onError) {
+        this.onError = onError;
+    }
+
+    public Integer getRetries() {
+        return retries;
+    }
+
+    public void setRetries(Integer retries) {
+        this.retries = retries;
+    }
+
+    public Long getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Long timeout) {
+        this.timeout = timeout;
+    }
+
+    public String getPriorityName() {
+        return priorityName;
+    }
+
+    public void setPriorityName(String priorityName) {
+        this.priorityName = priorityName;
+    }
+
+    public java.util.Map<String, Object> getData() {
+        return data;
+    }
+
+    public void setData(java.util.Map<String, Object> data) {
+        this.data = data;
+    }
+}

--- a/code/iaas/external-handler/src/main/java/io/cattle/platform/extension/dynamic/process/ExternalHandlerActivate.java
+++ b/code/iaas/external-handler/src/main/java/io/cattle/platform/extension/dynamic/process/ExternalHandlerActivate.java
@@ -1,7 +1,7 @@
 package io.cattle.platform.extension.dynamic.process;
 
-import static io.cattle.platform.core.model.tables.ExternalHandlerExternalHandlerProcessMapTable.*;
-import static io.cattle.platform.core.model.tables.ExternalHandlerProcessTable.*;
+import static io.cattle.platform.core.model.tables.ExternalHandlerExternalHandlerProcessMapTable.EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP;
+import static io.cattle.platform.core.model.tables.ExternalHandlerProcessTable.EXTERNAL_HANDLER_PROCESS;
 import io.cattle.platform.core.constants.ExternalHandlerConstants;
 import io.cattle.platform.core.dao.GenericMapDao;
 import io.cattle.platform.core.model.ExternalHandler;
@@ -10,14 +10,18 @@ import io.cattle.platform.core.model.ExternalHandlerProcess;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.extension.dynamic.api.addon.ExternalHandlerProcessConfig;
+import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.lock.LockCallback;
 import io.cattle.platform.lock.LockManager;
 import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
 
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -25,42 +29,47 @@ public class ExternalHandlerActivate extends AbstractDefaultProcessHandler {
 
     LockManager lockManager;
     GenericMapDao mapDao;
+    @Inject
+    JsonMapper jsonMapper;
 
     @Override
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
         ExternalHandler externalHandler = (ExternalHandler) state.getResource();
 
-        List<String> eventNames = new ArrayList<String>();
-        DataAccessor accessor = DataAccessor.fields(externalHandler).withKey(ExternalHandlerConstants.FIELD_PROCESS_NAMES);
+        Map<String, String> processConfigs = new HashMap<String, String>();
+        DataAccessor accessor = DataAccessor.fields(externalHandler).withKey(ExternalHandlerConstants.FIELD_PROCESS_CONFIGS);
 
-        List<?> list = accessor.as(List.class);
+        List<? extends ExternalHandlerProcessConfig> list = accessor.asList(jsonMapper, ExternalHandlerProcessConfig.class);
         if (list != null) {
-            for (Object obj : accessor.as(List.class)) {
-                for (String part : obj.toString().trim().split("\\s*,\\s*")) {
-                    eventNames.add(part);
+            for (ExternalHandlerProcessConfig config : list) {
+                String name = config.getName();
+                for (String part : name.toString().trim().split("\\s*,\\s*")) {
+                    processConfigs.put(part, config.getOnError());
                 }
             }
         }
 
-        if (eventNames.size() > 0) {
+        if (!processConfigs.isEmpty()) {
             for (ExternalHandlerExternalHandlerProcessMap map : getObjectManager().children(externalHandler, ExternalHandlerExternalHandlerProcessMap.class)) {
                 ExternalHandlerProcess handlerProcess = getObjectManager().loadResource(ExternalHandlerProcess.class, map.getExternalHandlerProcessId());
-                eventNames.remove(handlerProcess.getName());
+                processConfigs.remove(handlerProcess.getName());
             }
         }
 
-        if (eventNames.size() > 0) {
-            for (final String eventName : eventNames) {
-                ExternalHandlerProcess handlerProcess = lockManager.lock(new CreateExternalHandlerProcessLock(eventName),
+        if (!processConfigs.isEmpty()) {
+            for (Iterator<String> iter = processConfigs.keySet().iterator(); iter.hasNext();) {
+                final String processName = iter.next();
+                ExternalHandlerProcess handlerProcess = lockManager.lock(new CreateExternalHandlerProcessLock(processName),
                         new LockCallback<ExternalHandlerProcess>() {
                             @Override
                             public ExternalHandlerProcess doWithLock() {
-                                return getExternalHandlerProcess(eventName);
+                                return getExternalHandlerProcess(processName);
                             }
                         });
 
                 getObjectManager().create(ExternalHandlerExternalHandlerProcessMap.class, EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP.EXTERNAL_HANDLER_ID,
-                        externalHandler.getId(), EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP.EXTERNAL_HANDLER_PROCESS_ID, handlerProcess.getId());
+                        externalHandler.getId(), EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP.EXTERNAL_HANDLER_PROCESS_ID, handlerProcess.getId(),
+                        EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP.ON_ERROR, processConfigs.get(processName));
             }
         }
 

--- a/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
+++ b/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
@@ -138,8 +138,9 @@
     <!-- Physical Host -->  
     <process:process name="physicalhost.create" resourceType="physicalHost" start="requested" transitioning="creating" done="created" delegate="physicalhost.bootstrap" />
     <process:process name="physicalhost.bootstrap" resourceType="physicalHost" start="created,creating" transitioning="bootstrapping" done="active" />
-    <process:process name="physicalhost.remove" resourceType="physicalHost" start="active,requested,bootstrapping,creating,updating" transitioning="removing" done="removed" />
+    <process:process name="physicalhost.remove" resourceType="physicalHost" start="active,requested,bootstrapping,creating,updating,error,erroring" transitioning="removing" done="removed" />
     <process:process name="physicalhost.update" resourceType="physicalHost" start="active" transitioning="updating" done="active" />
+    <process:process name="physicalhost.error" resourceType="physicalHost" start="creating, bootstrapping, updating" transitioning="erroring" done="error" />
 
     <!-- Cluster host map -->
     <process:process name="clusterhostmap.create" resourceType="clusterHostMap" start="requested" transitioning="creating" done="created" />

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ExternalHandlerConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ExternalHandlerConstants.java
@@ -4,7 +4,7 @@ public class ExternalHandlerConstants {
 
     public static final String FIELD_RETRIES = "retries";
     public static final String FIELD_TIMEOUT = "timeoutMillis";
-    public static final String FIELD_PROCESS_NAMES = "processNames";
     public static final String FIELD_PRIORITY_NAME = "priorityName";
-
+    public static final String FIELD_PROCESS_CONFIGS = "processConfigs";
+    public static final String FIELD_EXTERNAL_HANDLER_PROCESS_CONFIG = "externalHandlerProcessConfig";
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/ExternalHandlerExternalHandlerProcessMap.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/ExternalHandlerExternalHandlerProcessMap.java
@@ -146,6 +146,17 @@ public interface ExternalHandlerExternalHandlerProcessMap extends java.io.Serial
 	@javax.persistence.Column(name = "external_handler_process_id", precision = 19)
 	public java.lang.Long getExternalHandlerProcessId();
 
+	/**
+	 * Setter for <code>cattle.external_handler_external_handler_process_map.on_error</code>.
+	 */
+	public void setOnError(java.lang.String value);
+
+	/**
+	 * Getter for <code>cattle.external_handler_external_handler_process_map.on_error</code>.
+	 */
+	@javax.persistence.Column(name = "on_error", length = 255)
+	public java.lang.String getOnError();
+
 	// -------------------------------------------------------------------------
 	// FROM and INTO
 	// -------------------------------------------------------------------------

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/ExternalHandlerExternalHandlerProcessMapTable.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/ExternalHandlerExternalHandlerProcessMapTable.java
@@ -11,7 +11,7 @@ package io.cattle.platform.core.model.tables;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class ExternalHandlerExternalHandlerProcessMapTable extends org.jooq.impl.TableImpl<io.cattle.platform.core.model.tables.records.ExternalHandlerExternalHandlerProcessMapRecord> {
 
-	private static final long serialVersionUID = 347958899;
+	private static final long serialVersionUID = 844682636;
 
 	/**
 	 * The singleton instance of <code>cattle.external_handler_external_handler_process_map</code>
@@ -85,6 +85,11 @@ public class ExternalHandlerExternalHandlerProcessMapTable extends org.jooq.impl
 	 * The column <code>cattle.external_handler_external_handler_process_map.external_handler_process_id</code>.
 	 */
 	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.ExternalHandlerExternalHandlerProcessMapRecord, java.lang.Long> EXTERNAL_HANDLER_PROCESS_ID = createField("external_handler_process_id", org.jooq.impl.SQLDataType.BIGINT, this, "");
+
+	/**
+	 * The column <code>cattle.external_handler_external_handler_process_map.on_error</code>.
+	 */
+	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.ExternalHandlerExternalHandlerProcessMapRecord, java.lang.String> ON_ERROR = createField("on_error", org.jooq.impl.SQLDataType.VARCHAR.length(255), this, "");
 
 	/**
 	 * Create a <code>cattle.external_handler_external_handler_process_map</code> table reference

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/ExternalHandlerExternalHandlerProcessMapRecord.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/ExternalHandlerExternalHandlerProcessMapRecord.java
@@ -11,9 +11,9 @@ package io.cattle.platform.core.model.tables.records;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 @javax.persistence.Entity
 @javax.persistence.Table(name = "external_handler_external_handler_process_map", schema = "cattle")
-public class ExternalHandlerExternalHandlerProcessMapRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.ExternalHandlerExternalHandlerProcessMapRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record12<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long>, io.cattle.platform.core.model.ExternalHandlerExternalHandlerProcessMap {
+public class ExternalHandlerExternalHandlerProcessMapRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.ExternalHandlerExternalHandlerProcessMapRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record13<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long, java.lang.String>, io.cattle.platform.core.model.ExternalHandlerExternalHandlerProcessMap {
 
-	private static final long serialVersionUID = -51503254;
+	private static final long serialVersionUID = 804964876;
 
 	/**
 	 * Setter for <code>cattle.external_handler_external_handler_process_map.id</code>.
@@ -220,6 +220,23 @@ public class ExternalHandlerExternalHandlerProcessMapRecord extends org.jooq.imp
 		return (java.lang.Long) getValue(11);
 	}
 
+	/**
+	 * Setter for <code>cattle.external_handler_external_handler_process_map.on_error</code>.
+	 */
+	@Override
+	public void setOnError(java.lang.String value) {
+		setValue(12, value);
+	}
+
+	/**
+	 * Getter for <code>cattle.external_handler_external_handler_process_map.on_error</code>.
+	 */
+	@javax.persistence.Column(name = "on_error", length = 255)
+	@Override
+	public java.lang.String getOnError() {
+		return (java.lang.String) getValue(12);
+	}
+
 	// -------------------------------------------------------------------------
 	// Primary key information
 	// -------------------------------------------------------------------------
@@ -233,23 +250,23 @@ public class ExternalHandlerExternalHandlerProcessMapRecord extends org.jooq.imp
 	}
 
 	// -------------------------------------------------------------------------
-	// Record12 type implementation
+	// Record13 type implementation
 	// -------------------------------------------------------------------------
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public org.jooq.Row12<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long> fieldsRow() {
-		return (org.jooq.Row12) super.fieldsRow();
+	public org.jooq.Row13<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long, java.lang.String> fieldsRow() {
+		return (org.jooq.Row13) super.fieldsRow();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public org.jooq.Row12<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long> valuesRow() {
-		return (org.jooq.Row12) super.valuesRow();
+	public org.jooq.Row13<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long, java.lang.String> valuesRow() {
+		return (org.jooq.Row13) super.valuesRow();
 	}
 
 	/**
@@ -352,6 +369,14 @@ public class ExternalHandlerExternalHandlerProcessMapRecord extends org.jooq.imp
 	 * {@inheritDoc}
 	 */
 	@Override
+	public org.jooq.Field<java.lang.String> field13() {
+		return io.cattle.platform.core.model.tables.ExternalHandlerExternalHandlerProcessMapTable.EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP.ON_ERROR;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public java.lang.Long value1() {
 		return getId();
 	}
@@ -442,6 +467,14 @@ public class ExternalHandlerExternalHandlerProcessMapRecord extends org.jooq.imp
 	@Override
 	public java.lang.Long value12() {
 		return getExternalHandlerProcessId();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public java.lang.String value13() {
+		return getOnError();
 	}
 
 	/**
@@ -556,7 +589,16 @@ public class ExternalHandlerExternalHandlerProcessMapRecord extends org.jooq.imp
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ExternalHandlerExternalHandlerProcessMapRecord values(java.lang.Long value1, java.lang.String value2, java.lang.String value3, java.lang.String value4, java.lang.String value5, java.lang.String value6, java.util.Date value7, java.util.Date value8, java.util.Date value9, java.util.Map<String,Object> value10, java.lang.Long value11, java.lang.Long value12) {
+	public ExternalHandlerExternalHandlerProcessMapRecord value13(java.lang.String value) {
+		setOnError(value);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ExternalHandlerExternalHandlerProcessMapRecord values(java.lang.Long value1, java.lang.String value2, java.lang.String value3, java.lang.String value4, java.lang.String value5, java.lang.String value6, java.util.Date value7, java.util.Date value8, java.util.Date value9, java.util.Map<String,Object> value10, java.lang.Long value11, java.lang.Long value12, java.lang.String value13) {
 		return this;
 	}
 
@@ -581,6 +623,7 @@ public class ExternalHandlerExternalHandlerProcessMapRecord extends org.jooq.imp
 		setData(from.getData());
 		setExternalHandlerId(from.getExternalHandlerId());
 		setExternalHandlerProcessId(from.getExternalHandlerProcessId());
+		setOnError(from.getOnError());
 	}
 
 	/**
@@ -606,7 +649,7 @@ public class ExternalHandlerExternalHandlerProcessMapRecord extends org.jooq.imp
 	/**
 	 * Create a detached, initialised ExternalHandlerExternalHandlerProcessMapRecord
 	 */
-	public ExternalHandlerExternalHandlerProcessMapRecord(java.lang.Long id, java.lang.String name, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.Long externalHandlerId, java.lang.Long externalHandlerProcessId) {
+	public ExternalHandlerExternalHandlerProcessMapRecord(java.lang.Long id, java.lang.String name, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.Long externalHandlerId, java.lang.Long externalHandlerProcessId, java.lang.String onError) {
 		super(io.cattle.platform.core.model.tables.ExternalHandlerExternalHandlerProcessMapTable.EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP);
 
 		setValue(0, id);
@@ -621,5 +664,6 @@ public class ExternalHandlerExternalHandlerProcessMapRecord extends org.jooq.imp
 		setValue(9, data);
 		setValue(10, externalHandlerId);
 		setValue(11, externalHandlerProcessId);
+		setValue(12, onError);
 	}
 }

--- a/code/iaas/model/src/main/resources/META-INF/cattle/core-model/spring-core-model-context.xml
+++ b/code/iaas/model/src/main/resources/META-INF/cattle/core-model/spring-core-model-context.xml
@@ -22,6 +22,7 @@
                 <value>io.cattle.platform.core.addon.LoadBalancerAppCookieStickinessPolicy</value>
                 <value>io.cattle.platform.core.addon.GlobalLoadBalancerPolicy</value>
                 <value>io.cattle.platform.core.addon.GlobalLoadBalancerHealthCheck</value>
+                <value>io.cattle.platform.extension.dynamic.api.addon.ExternalHandlerProcessConfig</value>
             </set>
         </property>
     </bean>

--- a/resources/content/db/changelog.xml
+++ b/resources/content/db/changelog.xml
@@ -33,5 +33,6 @@
     <include file="db/core-026.xml"/>
     <include file="db/core-027.xml"/>
     <include file="db/core-028.xml"/>
+    <include file="db/core-029.xml"/>
 
 </databaseChangeLog>

--- a/resources/content/db/core-029.xml
+++ b/resources/content/db/core-029.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    <property name="mediumtext" value="TEXT" dbms="postgresql" />
+    <property name="mediumtext" value="MEDIUMTEXT" />
+    <changeSet author="willchan (generated)" id="dump1">
+        <addColumn tableName="external_handler_external_handler_process_map">
+            <column name="on_error" type="VARCHAR(255)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/resources/content/schema/admin/admin-auth.json
+++ b/resources/content/schema/admin/admin-auth.json
@@ -63,13 +63,17 @@
         "externalHandler" : "cru",
         "externalHandler.priority" : "cru",
         "externalHandler.priorityString" : "cru",
-        "externalHandler.processNames" : "cr",
+        "externalHandler.processConfigs" : "cr",
+        "externalHandlerProcessConfig" : "cr",
+        "externalHandlerProcessConfig.name" : "cr",
+        "externalHandlerProcessConfig.onError" : "cr",
         "externalHandler.retries" : "cru",
         "externalHandler.timeoutMillis" : "cru",
 
         "externalHandlerExternalHandlerProcessMap" : "r",
         "externalHandlerExternalHandlerProcessMap.externalHandlerId" : "r",
         "externalHandlerExternalHandlerProcessMap.externalHandlerProcessId" : "r",
+        "externalHandlerExternalHandlerProcessMap.onError" : "r",
         "externalHandlerProcess" : "r",
 
         "githubconfig": "cru",

--- a/resources/content/schema/base/externalHandler.json
+++ b/resources/content/schema/base/externalHandler.json
@@ -9,8 +9,8 @@
                 "default_override"
             ]
         },
-        "processNames" : {
-            "type" : "array[string]",
+        "processConfigs" : {
+            "type" : "array[externalHandlerProcessConfig]",
             "required" : true,
             "includeInList" : false
         },

--- a/tests/integration/cattletest/core/test_external_handler.py
+++ b/tests/integration/cattletest/core/test_external_handler.py
@@ -34,21 +34,23 @@ def _disable_test_handlers(admin_client):
 
 def test_external_handler(admin_client):
     name = '{}-{}'.format(TEST_HANDLER_PREFIX, random_str())
+    configs = [{'name': 'instance.start', 'onError': 'instance.stop'}]
     h = admin_client.create_external_handler(name=name,
-                                             processNames=['instance.start'])
+                                             processConfigs=configs)
 
     assert h.state == 'registering'
-    assert h.get('processNames') is None
-    assert h.data.fields.processNames == ['instance.start']
+    assert h.get('processConfigs') is None
+    assert h.data.fields.processConfigs == configs
 
     h = wait_success(admin_client, h)
 
     assert h.state == 'active'
-    assert h.data.fields.processNames is None
+    assert h.data.fields.processConfigs is None
 
     maps = h.externalHandlerExternalHandlerProcessMaps()
     assert len(maps) == 1
     assert maps[0].state == 'active'
+    assert maps[0].onError == 'instance.stop'
 
     process = maps[0].externalHandlerProcess()
     assert process.state == 'active'
@@ -60,8 +62,9 @@ def test_external_handler(admin_client):
 
 def test_defaults(admin_client):
     name = '{}-{}'.format(TEST_HANDLER_PREFIX, random_str())
+    configs = [{'name': 'instance.start'}]
     h = admin_client.create_external_handler(name=name,
-                                             processNames=['instance.start'])
+                                             processConfigs=configs)
     h = wait_success(admin_client, h)
     assert h.state == 'active'
 
@@ -77,8 +80,9 @@ def test_defaults(admin_client):
 
 def test_properties(admin_client):
     name = '{}-{}'.format(TEST_HANDLER_PREFIX, random_str())
+    configs = [{'name': 'instance.start'}]
     h = admin_client.create_external_handler(name=name,
-                                             processNames=['instance.start'],
+                                             processConfigs=configs,
                                              timeoutMillis=2000,
                                              retries=4,
                                              priority=1234)
@@ -97,9 +101,9 @@ def test_properties(admin_client):
 
 def test_pre_handler(admin_client):
     name = '{}-{}'.format(TEST_HANDLER_PREFIX, random_str())
-    process_names = ['pre.instance.start']
+    configs = [{'name': 'pre.instance.start'}]
     h = admin_client.create_external_handler(name=name,
-                                             processNames=process_names,
+                                             processConfigs=configs,
                                              timeoutMillis=2000,
                                              retries=4,
                                              priority=1234)
@@ -115,9 +119,9 @@ def test_pre_handler(admin_client):
 
 def test_post_handler(admin_client):
     name = '{}-{}'.format(TEST_HANDLER_PREFIX, random_str())
-    event_names = ['post.instance.start']
+    configs = [{'name': 'post.instance.start'}]
     h = admin_client.create_external_handler(name=name,
-                                             processNames=event_names,
+                                             processConfigs=configs,
                                              timeoutMillis=2000,
                                              retries=4,
                                              priority=1234)
@@ -133,8 +137,9 @@ def test_post_handler(admin_client):
 
 def test_enabled_disable(admin_client):
     name = '{}-{}'.format(TEST_HANDLER_PREFIX, random_str())
+    configs = [{'name': 'instance.start'}]
     h = admin_client.create_external_handler(name=name,
-                                             processNames=['instance.start'])
+                                             processConfigs=configs)
     h = wait_success(admin_client, h)
 
     ep = _get_extension(admin_client, 'process.instance.start.handlers',
@@ -176,9 +181,9 @@ def test_enabled_disable(admin_client):
 
 def test_event_name_comma(admin_client):
     name = '{}-{}'.format(TEST_HANDLER_PREFIX, random_str())
-    event_names = ['pre.instance.start,instance.start'],
+    configs = [{'name': 'pre.instance.start,instance.start'}]
     h = admin_client.create_external_handler(name=name,
-                                             processNames=event_names)
+                                             processConfigs=configs)
     h = wait_success(admin_client, h)
 
     processes = [x.name for x in h.externalHandlerProcesses()]


### PR DESCRIPTION
This PR introduced error handling for ExternalHandlers.  It will still require additional PR from go-machine-service and go-rancher to make it work end to end.

Requires:
https://github.com/rancherio/go-rancher/pull/7
https://github.com/rancherio/go-machine-service/pull/20
