### PR TITLE
ServiceDiscovery:deactivate/remove commands are async now

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/EnvironmentRemove.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/EnvironmentRemove.java
@@ -1,16 +1,12 @@
 package io.cattle.platform.servicediscovery.process;
 
-import io.cattle.platform.archaius.util.ArchaiusUtil;
-import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.model.Environment;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
-import io.cattle.platform.engine.process.impl.ProcessCancelException;
 import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.resource.ResourceMonitor;
-import io.cattle.platform.object.resource.ResourcePredicate;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
 import io.cattle.platform.process.progress.ProcessProgress;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
@@ -21,12 +17,8 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import com.netflix.config.DynamicLongProperty;
-
 @Named
 public class EnvironmentRemove extends AbstractObjectProcessHandler {
-
-    private static final DynamicLongProperty TIMEOUT = ArchaiusUtil.getLong("service.remove.wait.time.millis");
 
     @Inject
     ResourceMonitor resourceMonitor;
@@ -55,21 +47,8 @@ public class EnvironmentRemove extends AbstractObjectProcessHandler {
 
     private void removeServices(List<? extends Service> services) {
         for (Service service : services) {
-            try {
-                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE,
+            objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE,
                         service, null);
-            } catch (ProcessCancelException e) {
-                // do nothing
-            }
-        }
-        for (Service service : services) {
-            progress.checkPoint("remove service " + service.getName());
-            service = resourceMonitor.waitFor(service, TIMEOUT.get(), new ResourcePredicate<Service>() {
-                @Override
-                public boolean evaluate(Service obj) {
-                    return CommonStatesConstants.REMOVED.equals(obj.getState());
-                }
-            });
         }
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDeactivate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDeactivate.java
@@ -6,10 +6,8 @@ import io.cattle.platform.core.model.Service;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
-import io.cattle.platform.engine.process.impl.ProcessCancelException;
 import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.object.resource.ResourceMonitor;
-import io.cattle.platform.object.resource.ResourcePredicate;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
 import io.cattle.platform.process.progress.ProcessProgress;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
@@ -53,20 +51,7 @@ public class ServiceDeactivate extends AbstractObjectProcessHandler {
 
     private void stopInstances(List<Instance> instances) {
         for (Instance instance : instances) {
-            try {
-                objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_STOP, instance, null);
-            } catch (ProcessCancelException e) {
-                // do nothing
-            }
-        }
-        for (Instance instance : instances) {
-            progress.checkPoint("stop service instance " + instance.getUuid());
-            instance = resourceMonitor.waitFor(instance, new ResourcePredicate<Instance>() {
-                @Override
-                public boolean evaluate(Instance obj) {
-                    return InstanceConstants.STATE_STOPPED.equals(obj.getState());
-                }
-            });
+            objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_STOP, instance, null);
         }
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceRemove.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceRemove.java
@@ -1,6 +1,5 @@
 package io.cattle.platform.servicediscovery.process;
 
-import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.dao.GenericMapDao;
 import io.cattle.platform.core.model.Instance;
@@ -10,12 +9,13 @@ import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
 import io.cattle.platform.engine.process.impl.ProcessCancelException;
+import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.resource.ResourceMonitor;
-import io.cattle.platform.object.resource.ResourcePredicate;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
 import io.cattle.platform.process.progress.ProcessProgress;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
+import io.cattle.platform.util.type.CollectionUtils;
 
 import java.util.List;
 
@@ -44,7 +44,6 @@ public class ServiceRemove extends AbstractObjectProcessHandler {
 
         if (!instances.isEmpty()) {
             progress.init(state, sdServer.getWeights(instances.size() * 2, 100));
-            stopInstances(instances);
             removeInstances(instances);
         }
         removeServiceMaps(service);
@@ -56,48 +55,22 @@ public class ServiceRemove extends AbstractObjectProcessHandler {
         return new String[] { ServiceDiscoveryConstants.PROCESS_SERVICE_REMOVE };
     }
 
-    private void stopInstances(List<Instance> instances) {
-        for (Instance instance : instances) {
-            try {
-                objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_STOP, instance, null);
-            } catch (ProcessCancelException e) {
-                // do nothing
-            }
-        }
-        for (Instance instance : instances) {
-            progress.checkPoint("stop service instance " + instance.getUuid());
-            instance = resourceMonitor.waitFor(instance, new ResourcePredicate<Instance>() {
-                @Override
-                public boolean evaluate(Instance obj) {
-                    return InstanceConstants.STATE_STOPPED.equals(obj.getState());
-                }
-            });
-        }
-    }
-
     private void removeInstances(List<Instance> instances) {
         for (Instance instance : instances) {
             try {
-                objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_REMOVE, instance, null);
+                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, instance, null);
             } catch (ProcessCancelException e) {
-                // do nothing
+                objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_STOP, instance,
+                        CollectionUtils.asMap(InstanceConstants.REMOVE_OPTION,
+                                true));
             }
-        }
-        for (Instance instance : instances) {
-            progress.checkPoint("remove service instance " + instance.getUuid());
-            instance = resourceMonitor.waitFor(instance, new ResourcePredicate<Instance>() {
-                @Override
-                public boolean evaluate(Instance obj) {
-                    return CommonStatesConstants.REMOVED.equals(obj.getState());
-                }
-            });
         }
     }
 
     private void removeServiceMaps(Service service) {
         for (ServiceConsumeMap map : mapDao.findToRemove(ServiceConsumeMap.class, Service.class, service.getId())) {
-            objectProcessManager.executeProcess(ServiceDiscoveryConstants.PROCESS_SERVICE_CONSUME_MAP_REMOVE, map,
-                    null);
+            objectProcessManager.scheduleProcessInstance(ServiceDiscoveryConstants.PROCESS_SERVICE_CONSUME_MAP_REMOVE,
+                    map, null);
         }
     }
 }


### PR DESCRIPTION
Schedule deactivate/remove processes for corresponding
instances/services and return the result. Used to wait for removal
completion before