### PR TITLE
Addressed various LB bugs

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
@@ -94,7 +94,8 @@ public class LoadBalancerInfoFactory extends AbstractAgentBaseContextFactory {
             if (ipAddress == null) {
                 Instance userInstance = objectManager.loadResource(Instance.class, target.getInstanceId());
                 if (userInstance.getState().equalsIgnoreCase(InstanceConstants.STATE_RUNNING)
-                        || userInstance.getState().equalsIgnoreCase(InstanceConstants.STATE_STARTING)) {
+                        || userInstance.getState().equalsIgnoreCase(InstanceConstants.STATE_STARTING)
+                        || userInstance.getState().equalsIgnoreCase(InstanceConstants.STATE_RESTARTING)) {
                     for (Nic nic : objectManager.children(userInstance, Nic.class)) {
                         IpAddress ip = ipAddressDao.getPrimaryIpAddress(nic);
                         if (ip != null) {
@@ -104,6 +105,7 @@ public class LoadBalancerInfoFactory extends AbstractAgentBaseContextFactory {
                     }
                 }
             }
+
             if (ipAddress != null) {
                 String targetName = (target.getName() == null ? target.getUuid() : target.getName());
                 targetsInfo.add(new LoadBalancerTargetInfo(ipAddress, targetName, target.getUuid()));

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/lock/LoadBalancerInstancePortLock.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/lock/LoadBalancerInstancePortLock.java
@@ -1,0 +1,10 @@
+package io.cattle.platform.lb.instance.process.lock;
+
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.lock.definition.AbstractBlockingLockDefintion;
+
+public class LoadBalancerInstancePortLock extends AbstractBlockingLockDefintion {
+    public LoadBalancerInstancePortLock(Instance lbInstance) {
+        super("LOADBALANCER.INSTANCE." + lbInstance.getId());
+    }
+}

--- a/code/iaas/lb-instance/src/main/resources/META-INF/cattle/system-services/lb-instance-defaults.properties
+++ b/code/iaas/lb-instance/src/main/resources/META-INF/cattle/system-services/lb-instance-defaults.properties
@@ -1,5 +1,5 @@
 lb.instance.name=Lb Agent
 lb.config.items=haproxy
 
-lb.instance.update.config.item.processes=loadbalancerconfiglistenermap.create,loadbalancerconfiglistenermap.remove,loadbalancertarget.create,loadbalancertarget.remove,loadbalancerhostmap.create,instance.start, instance.stop,loadbalancerconfig.update,${lb.instance.update.config.item.processes.extra}
+lb.instance.update.config.item.processes=loadbalancerconfiglistenermap.create,loadbalancerconfiglistenermap.remove,loadbalancertarget.create,loadbalancertarget.remove,loadbalancerhostmap.create,instance.start,instance.restart,instance.stop,loadbalancerconfig.update,${lb.instance.update.config.item.processes.extra}
 lb.instance.update.config.item.processes.extra=

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStop.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStop.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.process.instance;
 
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.InstanceLinkConstants;
 import io.cattle.platform.core.dao.GenericMapDao;
@@ -71,7 +72,9 @@ public class InstanceStop extends AbstractDefaultProcessHandler {
         }
 
         for (Port port : getObjectManager().children(instance, Port.class)) {
-            deactivate(port, null);
+            if (port.getRemoved() == null && !port.getState().equals(CommonStatesConstants.REMOVED)) {
+                deactivate(port, null);
+            }
         }
 
         for (InstanceLink link : getObjectManager().children(instance, InstanceLink.class, InstanceLinkConstants.FIELD_INSTANCE_ID)) {

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -47,6 +47,7 @@ public class InstanceConstants {
     public static final String STATE_RUNNING = "running";
     public static final String STATE_STOPPED = "stopped";
     public static final String STATE_STARTING = "starting";
+    public static final String STATE_RESTARTING = "restarting";
 
     public static final String ON_STOP_STOP = "stop";
     public static final String ON_STOP_RESTART = "restart";

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/LoadBalancerTargetDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/LoadBalancerTargetDao.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.core.dao;
 
+import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.LoadBalancerTarget;
 
 import java.util.List;
@@ -17,5 +18,9 @@ public interface LoadBalancerTargetDao {
     LoadBalancerTarget getLbInstanceTargetToRemove(long lbId, long instanceId);
 
     LoadBalancerTarget getLbIpAddressTargetToRemove(long lbId, String ipAddress);
+
+    List<? extends Instance> getLoadBalancerActiveInstanceTargets(long lbId);
+
+    List<? extends LoadBalancerTarget> getLoadBalancerActiveIpTargets(long lbId);
 
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/LoadBalancerTargetDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/LoadBalancerTargetDaoImpl.java
@@ -1,9 +1,14 @@
 package io.cattle.platform.core.dao.impl;
 
+import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
+import static io.cattle.platform.core.model.tables.LoadBalancerListenerTable.LOAD_BALANCER_LISTENER;
 import static io.cattle.platform.core.model.tables.LoadBalancerTargetTable.LOAD_BALANCER_TARGET;
 import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.dao.LoadBalancerTargetDao;
+import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.LoadBalancerTarget;
+import io.cattle.platform.core.model.tables.records.InstanceRecord;
 import io.cattle.platform.core.model.tables.records.LoadBalancerTargetRecord;
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.object.ObjectManager;
@@ -75,6 +80,36 @@ public class LoadBalancerTargetDaoImpl extends AbstractJooqDao implements LoadBa
                 .where(
                         LOAD_BALANCER_TARGET.LOAD_BALANCER_ID.eq(lbId)
                                 .and(LOAD_BALANCER_TARGET.REMOVED.isNull()))
+                .fetchInto(LoadBalancerTargetRecord.class);
+    }
+
+    @Override
+    public List<? extends Instance> getLoadBalancerActiveInstanceTargets(long lbId) {
+        return create()
+                .select(INSTANCE.fields())
+                .from(INSTANCE)
+                .join(LOAD_BALANCER_TARGET)
+                .on(LOAD_BALANCER_TARGET.INSTANCE_ID.eq(INSTANCE.ID)
+                        .and(LOAD_BALANCER_TARGET.LOAD_BALANCER_ID.eq(lbId))
+                        .and(LOAD_BALANCER_TARGET.STATE.in(CommonStatesConstants.ACTIVATING,
+                                CommonStatesConstants.ACTIVE)))
+                .where(INSTANCE.REMOVED.isNull().and(
+                        INSTANCE.STATE.in(InstanceConstants.STATE_RUNNING, InstanceConstants.STATE_STARTING,
+                                InstanceConstants.STATE_RESTARTING)))
+                .fetchInto(InstanceRecord.class);
+    }
+
+    @Override
+    public List<? extends LoadBalancerTarget> getLoadBalancerActiveIpTargets(long lbId) {
+        return create()
+                .select(LOAD_BALANCER_TARGET.fields())
+                .from(LOAD_BALANCER_TARGET)
+                .where(LOAD_BALANCER_TARGET.REMOVED.isNull()
+                        .and(
+                        LOAD_BALANCER_TARGET.STATE.in(CommonStatesConstants.ACTIVATING,
+                                        CommonStatesConstants.ACTIVE))
+                        .and(LOAD_BALANCER_TARGET.IP_ADDRESS.isNotNull())
+                        .and(LOAD_BALANCER_TARGET.LOAD_BALANCER_ID.eq(lbId)))
                 .fetchInto(LoadBalancerTargetRecord.class);
     }
 }

--- a/tests/integration/cattletest/core/test_lb_lifecycle.py
+++ b/tests/integration/cattletest/core/test_lb_lifecycle.py
@@ -32,6 +32,12 @@ def test_add_lb_w_host_and_target(super_client, admin_client, sim_context,
 
     # check the port
     ports = super_client.list_port(publicPort=port, instanceId=instance.id)
+    assert len(ports) == 0
+
+    # start the instance and check the ports
+    container = container.start()
+    container = admin_client.wait_success(container)
+    ports = super_client.list_port(publicPort=port, instanceId=instance.id)
     assert len(ports) == 1
     assert ports[0].state == 'active'
     assert ports[0].publicPort == port
@@ -66,8 +72,7 @@ def test_destroy_lb_instance(super_client, admin_client, sim_context, nsp):
                                                          port, nsp)
     # add target to a load balancer
     image_uuid = sim_context['imageUuid']
-    container = admin_client.create_container(imageUuid=image_uuid,
-                                              startOnCreate=False)
+    container = admin_client.create_container(imageUuid=image_uuid)
     container = admin_client.wait_success(container)
     lb = lb.addtarget(instanceId=container.id)
     validate_add_target(container, lb, super_client)


### PR DESCRIPTION
1) handle instance.restart when update haproxy config
2) unbind public ports when there are no active lb targets
3) fixed the bug when duplicated ports were created for the same lb
instance

Also bug fix for instance.stop: don't try to deactivate purged/removed
ports