### PR TITLE
Enable Read access for lb map object types

### DIFF
--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -294,6 +294,14 @@
         "addRemoveServiceLinkInput" : "cr",
         "addRemoveServiceLinkInput.serviceId" : "cr",
 
+        "loadBalancerConfigListenerMap" : "r",
+        "loadBalancerConfigListenerMap.loadBalancerConfigId" : "r",
+        "loadBalancerConfigListenerMap.loadBalancerListenerId" : "r",
+
+        "loadBalancerHostMap" : "r",
+        "loadBalancerHostMap.hostId" : "r",
+        "loadBalancerHostMap.loadBalancerId" : "r",
+
         "end" : ""
     }
 }

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -588,3 +588,33 @@ def test_registry(admin_client, client):
         'accountId': 'r',
         'serverAddress': 'cr',
     })
+
+
+def test_lb_config_listener_map(admin_client, client):
+    auth_check(admin_client.schema, 'loadBalancerConfigListenerMap', 'r', {
+        'loadBalancerConfigId': 'r',
+        'loadBalancerListenerId': 'r',
+        'accountId': 'r',
+        'data': 'r',
+    })
+
+    auth_check(client.schema, 'loadBalancerConfigListenerMap', 'r', {
+        'loadBalancerConfigId': 'r',
+        'loadBalancerListenerId': 'r',
+        'accountId': 'r',
+    })
+
+
+def test_lb_host_map(admin_client, client):
+    auth_check(admin_client.schema, 'loadBalancerHostMap', 'r', {
+        'hostId': 'r',
+        'loadBalancerId': 'r',
+        'accountId': 'r',
+        'data': 'r',
+    })
+
+    auth_check(client.schema, 'loadBalancerHostMap', 'r', {
+        'hostId': 'r',
+        'loadBalancerId': 'r',
+        'accountId': 'r',
+    })


### PR DESCRIPTION
loadBalancerConfigListenerMap
loadBalancerHostMap

As we rely on the map states to reflect haproxy config changes, we should expose those objects to an end user.

@sonchang it will probably be similar to your host->cluster map

@sonchang @cjellick can you please review?