### PR TITLE
serviceDiscovery/lb bug fixes

### DIFF
--- a/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
+++ b/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
@@ -105,8 +105,8 @@
     <process:process name="loadbalancerconfig.update" resourceType="loadBalancerConfig" start="active" transitioning="updating-active" done="active" />
 
     <!-- Load Balancer Config Listener Map -->
-    <process:process name="loadbalancerconfiglistenermap.create" resourceType="loadBalancerConfigListeneMap" start="requested" transitioning="activating" done="active" />
-    <process:process name="loadbalancerconfiglistenermap.remove" resourceType="loadBalancerConfigListeneMap" start="active,activating" transitioning="removing" done="removed" />
+    <process:process name="loadbalancerconfiglistenermap.create" resourceType="loadBalancerConfigListenerMap" start="requested" transitioning="activating" done="active" />
+    <process:process name="loadbalancerconfiglistenermap.remove" resourceType="loadBalancerConfigListenerMap" start="active,activating" transitioning="removing" done="removed" />
 
     <!-- Global Load Balancer -->
     <process:process name="globalloadbalancer.create" resourceType="globalLoadBalancer" start="requested" transitioning="activating" done="active" />

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/resource/ServiceDiscoveryConfigItem.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/resource/ServiceDiscoveryConfigItem.java
@@ -54,6 +54,11 @@ public class ServiceDiscoveryConfigItem {
             "registryCredentialId", true, false);
     public static final ServiceDiscoveryConfigItem SCALE = new ServiceDiscoveryConfigItem("scale", "scale",
             false, false);
+    public static final ServiceDiscoveryConfigItem CPU_SET = new ServiceDiscoveryConfigItem("cpuSet",
+            "cpuSet", true, false);
+    public static final ServiceDiscoveryConfigItem REQUESTED_HOST_ID = new ServiceDiscoveryConfigItem(
+            InstanceConstants.FIELD_REQUESTED_HOST_ID, InstanceConstants.FIELD_REQUESTED_HOST_ID,
+            true, false);
 
     /**
      * Name as it appears in docker-compose file

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/RancherConfigToComposeFormatter.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/RancherConfigToComposeFormatter.java
@@ -1,0 +1,7 @@
+package io.cattle.platform.servicediscovery.service.impl;
+
+import io.cattle.platform.servicediscovery.resource.ServiceDiscoveryConfigItem;
+
+public interface RancherConfigToComposeFormatter {
+    public Object format(ServiceDiscoveryConfigItem item, Object valueToTransform);
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/RancherImageToComposeFormatter.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/RancherImageToComposeFormatter.java
@@ -1,0 +1,19 @@
+package io.cattle.platform.servicediscovery.service.impl;
+
+import io.cattle.platform.servicediscovery.resource.ServiceDiscoveryConfigItem;
+
+public class RancherImageToComposeFormatter implements RancherConfigToComposeFormatter {
+    private static final String IMAGE_PREFIX = "docker:";
+
+    @Override
+    public Object format(ServiceDiscoveryConfigItem item, Object valueToTransform) {
+        if (!item.getComposeName().equalsIgnoreCase(ServiceDiscoveryConfigItem.IMAGE.getComposeName())) {
+            return null;
+        }
+        if (valueToTransform.toString().startsWith(IMAGE_PREFIX)) {
+            valueToTransform = valueToTransform.toString().replaceFirst(IMAGE_PREFIX, "");
+        }
+        return valueToTransform;
+    }
+
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/RancherRestartToComposeFormatter.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/RancherRestartToComposeFormatter.java
@@ -1,0 +1,30 @@
+package io.cattle.platform.servicediscovery.service.impl;
+
+import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.servicediscovery.resource.ServiceDiscoveryConfigItem;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+public class RancherRestartToComposeFormatter implements RancherConfigToComposeFormatter {
+
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object format(ServiceDiscoveryConfigItem item, Object valueToTransform) {
+        if (!item.getComposeName().equalsIgnoreCase(ServiceDiscoveryConfigItem.RESTART.getComposeName())) {
+            return null;
+        }
+        // transform object to string as thats how policy is defined in docker-compose
+        Map<String, Object> map = (Map<String, Object>) valueToTransform;
+        Object name = map.get("name");
+        Object maxRetryCount = map.get("maximumRetryCount");
+        if (maxRetryCount == null) {
+            return name;
+        }
+        return name + ":" + maxRetryCount;
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
+++ b/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
@@ -30,6 +30,9 @@
        <bean class="io.cattle.platform.servicediscovery.api.action.EnvironmentDockerComposeLinkHandler" />
        <bean class="io.cattle.platform.servicediscovery.api.action.EnvironmentRancherComposeLinkHandler" />
        
+       <bean class="io.cattle.platform.servicediscovery.service.impl.RancherImageToComposeFormatter" />
+       <bean class="io.cattle.platform.servicediscovery.service.impl.RancherRestartToComposeFormatter" />
+       
        <bean class="io.cattle.platform.process.progress.ProcessProgressImpl" />
 
 </beans>

--- a/resources/content/schema/base/environment.json
+++ b/resources/content/schema/base/environment.json
@@ -1,7 +1,9 @@
 {
     "resourceFields": {
         "name":{
-            "required": true
+            "required": true,
+            "validChars": "[a-zA-Z0-9]",
+            "minLength": 1
         }
     },
     "resourceActions" : {

--- a/resources/content/schema/base/service.json
+++ b/resources/content/schema/base/service.json
@@ -22,7 +22,9 @@
             "nullable" : true
         },
         "name":{
-            "required": true
+            "required": true,
+            "validChars": "[a-zA-Z0-9]",
+            "minLength": 1
         },
         "launchConfig": {
             "type": "container",

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -12,7 +12,6 @@ def nsp(super_client, sim_context):
     return nsp
 
 
-@pytest.fixture(scope='module')
 def random_str():
     return 'random{0}'.format(random_num())
 
@@ -40,6 +39,7 @@ def test_activate_single_service(super_client, admin_client, sim_context, nsp):
     assert env.state == "active"
 
     image_uuid = sim_context['imageUuid']
+    host = sim_context['host']
     container1 = admin_client.create_container(imageUuid=image_uuid,
                                                startOnCreate=False)
     container1 = admin_client.wait_success(container1)
@@ -80,6 +80,7 @@ def test_activate_single_service(super_client, admin_client, sim_context, nsp):
                      "tty": True,
                      "entryPoint": ["/bin/sh", "-c"],
                      "cpuShares": 400,
+                     "cpuSet": "2",
                      "restartPolicy": restart_policy,
                      "directory": "/",
                      "hostname": "test",
@@ -87,7 +88,8 @@ def test_activate_single_service(super_client, admin_client, sim_context, nsp):
                      "instanceLinks": {
                          'container2_link':
                              container2.id},
-                     "registryCredentialId": reg_cred.id}
+                     "registryCredentialId": reg_cred.id,
+                     "requestedHostId": host.id}
 
     service = super_client.create_service(name=random_str(),
                                           environmentId=env.id,
@@ -158,6 +160,8 @@ def test_activate_single_service(super_client, admin_client, sim_context, nsp):
     assert container.user == "test"
     assert container.state == "running"
     assert container.registryCredentialId == reg_cred.id
+    assert container.cpuSet == "2"
+    assert container.requestedHostId == host.id
 
 
 def test_activate_services(super_client, admin_client, sim_context, nsp):

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -11,9 +11,11 @@ def nsp(super_client, sim_context):
 
     return nsp
 
+
 @pytest.fixture(scope='module')
 def random_str():
     return 'random{0}'.format(random_num())
+
 
 def create_env_and_svc(super_client, admin_client, nsp):
     env = admin_client.create_environment(name=random_str())

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -11,6 +11,9 @@ def nsp(super_client, sim_context):
 
     return nsp
 
+@pytest.fixture(scope='module')
+def random_str():
+    return 'random{0}'.format(random_num())
 
 def create_env_and_svc(super_client, admin_client, nsp):
     env = admin_client.create_environment(name=random_str())


### PR DESCRIPTION
1) Convert restarPolicy to format docker-compose understands: 

https://github.com/rancherio/rancher/issues/548

2) Allow only [a-zA-Z0-9] for service/environment name as those are the chars that can be used for Docker containers' names

3) fixed the typo in load balancer resource name.

4) Fixed private registry support - used to not work when credentials were required

https://github.com/rancherio/rancher/issues/572

5) Expose cpuSet and requestedHostId in service

https://github.com/rancherio/rancher/issues/576
https://github.com/rancherio/rancher/issues/549