### PR TITLE
hopefully fixes intermittent cluster TFs. looks like test_host_purge rem...

### DIFF
--- a/tests/integration/cattletest/core/test_cluster.py
+++ b/tests/integration/cattletest/core/test_cluster.py
@@ -96,6 +96,9 @@ def test_cluster_add_remove_host_actions(admin_client, super_client,
         lambda x: len(x.hosts()))
 
 
+# temporarily skipping since this was inadvertently deleting the
+# real host causing downstream TFs
+@pytest.mark.skipif('True')
 def test_host_purge(admin_client, super_client):
     new_context = create_sim_context(
         super_client, 'simagent' + random_str(), ip='192.168.10.14',


### PR DESCRIPTION
...oves main host
@alena1108 @cjellick 
I tried to take this into account when I first wrote the test, but looks like there are still issues with it.
What I noticed when I took a closer look was that test_host_purge() looked like it was wiping out the main  host (non-fake one).  In my case, boot2docker.  But I guess locally, it re-registered (amazing and oddly very quickly).  That's why I didn't see the TFs when running locally.  But it would explain why the failures are intermittent and also why the failures sometimes occur in different tests.
I'm taking the test out temporarily unless I have more time to research our test simulator framework better.  It's passed 2 drone tests now.