### PR TITLE
Make stateTransitions visible

### DIFF
--- a/resources/content/schema/admin/admin-auth.json
+++ b/resources/content/schema/admin/admin-auth.json
@@ -97,6 +97,8 @@
         "processDefinition.resourceType" : "r",
         "processDefinition.stateTransitions" : "r",
 
+        "stateTransition" : "r",
+
         "processExecution" : "r",
         "processExecution.log" : "r",
         "processExecution.processInstanceId" : "r",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -342,6 +342,7 @@ def test_process_definition(admin_client, client):
         'postProcessListeners': 'r',
         'processHandlers': 'r',
         'resourceType': 'r',
+        'stateTransitions': 'r',
     })
 
 


### PR DESCRIPTION
The `processDefinition.stateTransitions` field is set as readable, but the resource to which it points (`stateTransition`) is not. So, the field doesn't show up in the resource. This fixes that.