### PR TITLE
service discovery bug fixes

### DIFF
--- a/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
+++ b/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
@@ -141,6 +141,7 @@
 
     <!-- Service Discovery Environment -->
     <process:process name="environment.create" resourceType="environment" start="requested" transitioning="activating" done="active" />
+    <process:process name="environment.update" resourceType="environment" start="active" transitioning="updating-active" done="active" />
     <process:process name="environment.remove" resourceType="environment" start="active, activating" transitioning="removing" done="removed" />
     
     <!-- Service Discovery Service -->

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -27,10 +27,10 @@ public class ServiceDiscoveryConstants {
     public static final String PROCESS_SERVICE_CREATE = "service." + ACTION_SERVICE_CREATE;
     public static final String PROCESS_ENV_ACTIVATE_SERVICES = "environment." + ACTION_ENV_ACTIVATE_SERVICES;
     public static final String PROCESS_ENV_DEACTIVATE_SERVICES = "environment.deactivateservices";
+    public static final String PROCESS_ENV_UPDATE = "environment.update";
     public static final String PROCESS_ENV_REMOVE = "environment.remove";
     public static final String PROCESS_SERVICE_DEACTIVATE = "service.deactivate";
     public static final String PROCESS_SERVICE_REMOVE = "service.remove";
-    public static final String PROCESS_SERVICE_INSTANCE_MAP_REMOVE = "serviceexposemap.remove";
     public static final String PROCESS_ENV_EXPORT_CONFIG = "environment.exportconfig";
     public static final String PROCESS_SERVICE_ADD_SERVICE_LINK = "service." + ACTION_SERVICE_ADD_SERVICE_LINK;
     public static final String PROCESS_SERVICE_REMOVE_SERVICE_LINK = "service." + ACTION_SERVICE_REMOVE_SERVICE_LINK;

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/dao/ServiceExposeMapDao.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/dao/ServiceExposeMapDao.java
@@ -1,13 +1,56 @@
 package io.cattle.platform.servicediscovery.api.dao;
 
+import io.cattle.platform.core.model.Environment;
 import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceExposeMap;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ServiceExposeMapDao {
 
-    List<? extends Instance> listNonRemovedInstancesForService(long serviceId);
+    List<? extends Instance> listActiveServiceInstances(long serviceId);
 
-    Instance getServiceInstance(long serviceId, String instanceName);
+    Instance getActiveServiceInstance(long serviceId, String instanceName);
+
+    /**
+     * this method is wrapped up in transaction. All instances will get created and scheduled for create inside one
+     * transaction
+     * 
+     * @param properties
+     * @param service
+     * @param instanceName
+     * @return
+     */
+    Instance createServiceInstance(Map<Object, Object> properties, Service service, String instanceName);
+
+    List<? extends Instance> listServiceInstances(long serviceId);
+
+    /**
+     * Lists maps for service instances that are in removed state
+     * 
+     * @param serviceId
+     * @return
+     */
+    List<? extends ServiceExposeMap> listServiceRemovedInstancesMaps(long serviceId);
+
+    /**
+     * this method updates service's instances' names based on the environment/service name. Invoked on the
+     * service name change
+     * 
+     * @param service
+     */
+    void updateServiceName(Service service);
+
+    /**
+     * this method updates environment's instances' names based on the environment/service name. Invoked on the
+     * environment name change
+     * 
+     * @param environment
+     */
+    void updateEnvironmentName(Environment env);
+
+    List<? extends ServiceExposeMap> getNonRemovedServiceInstanceMap(long serviceId);
 
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/EnvironmentCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/EnvironmentCreateValidationFilter.java
@@ -27,6 +27,13 @@ public class EnvironmentCreateValidationFilter extends AbstractDefaultResourceMa
             ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_CHARACTERS,
                     "name");
         }
+
+        Environment existingEnv = objectManager.findOne(Environment.class, ENVIRONMENT.NAME, env.getName(),
+                ENVIRONMENT.REMOVED, null);
+        if (existingEnv != null) {
+            ValidationErrorCodes.throwValidationError(ValidationErrorCodes.NOT_UNIQUE,
+                    "name");
+        }
         return super.create(type, request, next);
     }
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
@@ -35,6 +35,7 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
             ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_CHARACTERS,
                     "name");
         }
+
         return super.create(type, request, next);
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/api/action/EnvironmentActivateServicesActionHandler.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/api/action/EnvironmentActivateServicesActionHandler.java
@@ -8,7 +8,7 @@ import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.object.process.ObjectProcessManager;
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
-import io.cattle.platform.servicediscovery.process.ServiceActivate;
+import io.cattle.platform.servicediscovery.process.ServiceUpdateActivate;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 
 import java.util.HashMap;
@@ -46,7 +46,7 @@ public class EnvironmentActivateServicesActionHandler implements ActionHandler {
 
     private void activateServices(List<? extends Service> services, Map<String, Object> data) {
         // flag for service.activate to indicate that the consumed services should be activated first
-        DataAccessor.fromMap(data).withScope(ServiceActivate.class)
+        DataAccessor.fromMap(data).withScope(ServiceUpdateActivate.class)
                 .withKey(ServiceDiscoveryConstants.FIELD_ACTIVATE_CONSUMED_SERVICES).set(true);
         for (Service service : services) {
             if (service.getState().equalsIgnoreCase(CommonStatesConstants.INACTIVE)) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceExposeMapDaoImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceExposeMapDaoImpl.java
@@ -3,16 +3,40 @@ package io.cattle.platform.servicediscovery.dao.impl;
 import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
 import static io.cattle.platform.core.model.tables.ServiceExposeMapTable.SERVICE_EXPOSE_MAP;
 import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.model.Environment;
 import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceExposeMap;
 import io.cattle.platform.core.model.tables.records.InstanceRecord;
+import io.cattle.platform.core.model.tables.records.ServiceExposeMapRecord;
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+import io.cattle.platform.deferred.util.DeferredUtils;
+import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.object.process.ObjectProcessManager;
+import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.servicediscovery.api.dao.ServiceExposeMapDao;
+import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import javax.inject.Inject;
 
 public class ServiceExposeMapDaoImpl extends AbstractJooqDao implements ServiceExposeMapDao {
+
+    @Inject
+    ObjectManager objectManager;
+
+    @Inject
+    ObjectProcessManager objectProcessManager;
+
+    @Inject
+    ServiceDiscoveryService sdService;
+
     @Override
-    public List<? extends Instance> listNonRemovedInstancesForService(long serviceId) {
+    public List<? extends Instance> listActiveServiceInstances(long serviceId) {
         return create()
                 .select(INSTANCE.fields())
                 .from(INSTANCE)
@@ -26,7 +50,7 @@ public class ServiceExposeMapDaoImpl extends AbstractJooqDao implements ServiceE
     }
 
     @Override
-    public Instance getServiceInstance(long serviceId, String instanceName) {
+    public Instance getActiveServiceInstance(long serviceId, String instanceName) {
         List<? extends Instance> instances = create()
                 .select(INSTANCE.fields())
                 .from(INSTANCE)
@@ -41,5 +65,95 @@ public class ServiceExposeMapDaoImpl extends AbstractJooqDao implements ServiceE
             return null;
         }
         return instances.get(0);
+    }
+
+    @Override
+    public Instance createServiceInstance(Map<Object, Object> properties, Service service, String instanceName) {
+        Map<String, Object> props = objectManager.convertToPropertiesFor(Instance.class,
+                properties);
+        final Instance instance = objectManager.create(Instance.class, props);
+        objectManager.create(ServiceExposeMap.class, SERVICE_EXPOSE_MAP.INSTANCE_ID, instance.getId(),
+                SERVICE_EXPOSE_MAP.SERVICE_ID, service.getId());
+        DeferredUtils.nest(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                objectProcessManager.scheduleStandardProcess(StandardProcess.CREATE, instance, null);
+                return null;
+            }
+        });
+        return objectManager.reload(instance);
+    }
+
+    @Override
+    public List<? extends Instance> listServiceInstances(long serviceId) {
+        return create()
+                .select(INSTANCE.fields())
+                .from(INSTANCE)
+                .join(SERVICE_EXPOSE_MAP)
+                .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID)
+                        .and(SERVICE_EXPOSE_MAP.SERVICE_ID.eq(serviceId))
+                        .and(SERVICE_EXPOSE_MAP.STATE.in(CommonStatesConstants.ACTIVATING,
+                                CommonStatesConstants.ACTIVE, CommonStatesConstants.REQUESTED)))
+                .where(INSTANCE.REMOVED.isNull())
+                .fetchInto(InstanceRecord.class);
+    }
+
+    @Override
+    public List<? extends ServiceExposeMap> listServiceRemovedInstancesMaps(long serviceId) {
+        return create()
+                .select(SERVICE_EXPOSE_MAP.fields())
+                .from(SERVICE_EXPOSE_MAP)
+                .join(INSTANCE)
+                .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID)
+                        .and(SERVICE_EXPOSE_MAP.SERVICE_ID.eq(serviceId))
+                        .and(SERVICE_EXPOSE_MAP.REMOVED.isNull()))
+                .where(INSTANCE.STATE.eq(CommonStatesConstants.REMOVED))
+                .fetchInto(ServiceExposeMapRecord.class);
+    }
+
+    @Override
+    public void updateServiceName(Service service) {
+        List<? extends Instance> instances = updateInstanceNames(service);
+        for (Instance instance : instances) {
+            objectManager.persist(instance);
+        }
+    }
+
+    private List<? extends Instance> updateInstanceNames(Service service) {
+        List<? extends Instance> instances = listServiceInstances(service.getId());
+        int i = 1;
+        for (Instance instance : instances) {
+            instance.setName(sdService.generateServiceInstanceName(service, i));
+            i++;
+        }
+        return instances;
+    }
+
+    @Override
+    public void updateEnvironmentName(Environment env) {
+        List<? extends Service> services = objectManager.mappedChildren(env, Service.class);
+        List<Instance> instances = new ArrayList<>();
+        for (Service service : services) {
+            if (service.getRemoved() == null && !service.getState().equalsIgnoreCase(CommonStatesConstants.REMOVED)
+                    && !service.getState().equalsIgnoreCase(CommonStatesConstants.REMOVING))
+                instances.addAll(updateInstanceNames(service));
+        }
+        for (Instance instance : instances) {
+            objectManager.persist(instance);
+        }
+    }
+
+    @Override
+    public List<? extends ServiceExposeMap> getNonRemovedServiceInstanceMap(long serviceId) {
+        return create()
+                .select(SERVICE_EXPOSE_MAP.fields())
+                .from(SERVICE_EXPOSE_MAP)
+                .join(INSTANCE)
+                .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID)
+                        .and(SERVICE_EXPOSE_MAP.SERVICE_ID.eq(serviceId))
+                        .and(SERVICE_EXPOSE_MAP.REMOVED.isNull().and(
+                                SERVICE_EXPOSE_MAP.STATE.notIn(CommonStatesConstants.REMOVED,
+                                        CommonStatesConstants.REMOVING))))
+                .fetchInto(ServiceExposeMapRecord.class);
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/EnvironmentUpdatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/EnvironmentUpdatePostListener.java
@@ -1,6 +1,6 @@
 package io.cattle.platform.servicediscovery.process;
 
-import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.Environment;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.handler.ProcessPostListener;
 import io.cattle.platform.engine.process.ProcessInstance;
@@ -17,13 +17,9 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-/**
- * this handler takes care of renaming service instances names based on environment/service name change
- */
 @Named
-public class ServiceUpdatePostListener extends AbstractObjectProcessLogic implements ProcessPostListener,
+public class EnvironmentUpdatePostListener extends AbstractObjectProcessLogic implements ProcessPostListener,
         Priority {
-
     @Inject
     ServiceExposeMapDao svcExposeDao;
 
@@ -32,12 +28,12 @@ public class ServiceUpdatePostListener extends AbstractObjectProcessLogic implem
 
     @Override
     public String[] getProcessNames() {
-        return new String[] { ServiceDiscoveryConstants.PROCESS_SERVICE_UPDATE };
+        return new String[] { ServiceDiscoveryConstants.PROCESS_ENV_UPDATE };
     }
 
     @Override
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
-        Service service = (Service) state.getResource();
+        Environment env = (Environment) state.getResource();
 
         // rename instances
         // rename only if name is different
@@ -46,8 +42,8 @@ public class ServiceUpdatePostListener extends AbstractObjectProcessLogic implem
 
         if (old != null) {
             Object oldName = old.get("name");
-            if (oldName != null && !oldName.toString().equalsIgnoreCase(service.getName())) {
-                svcExposeDao.updateServiceName(service);
+            if (oldName != null && !oldName.toString().equalsIgnoreCase(env.getName())) {
+                svcExposeDao.updateEnvironmentName(env);
             }
         }
 
@@ -58,5 +54,4 @@ public class ServiceUpdatePostListener extends AbstractObjectProcessLogic implem
     public int getPriority() {
         return Priority.DEFAULT;
     }
-
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceCleanupPreListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceCleanupPreListener.java
@@ -1,0 +1,80 @@
+package io.cattle.platform.servicediscovery.process;
+
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceExposeMap;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPreListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.object.process.StandardProcess;
+import io.cattle.platform.object.util.DataAccessor;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants.KIND;
+import io.cattle.platform.servicediscovery.api.dao.ServiceExposeMapDao;
+import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
+import io.cattle.platform.util.type.Priority;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * this handler takes care of
+ * a) removing service-instance mappings referencing instances in Removed state
+ * b) scaling down the service to the requested scale
+ * 
+ * the handler gets invoked on all processes associated with the service, so at the moment of process execution the
+ * server is in "clean" state
+ */
+@Named
+public class ServiceCleanupPreListener extends AbstractObjectProcessLogic implements ProcessPreListener,
+        Priority {
+
+    @Inject
+    ServiceExposeMapDao exposeMapDao;
+
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Inject
+    ServiceDiscoveryService sdService;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { ServiceDiscoveryConstants.PROCESS_SERVICE_ACTIVATE,
+                ServiceDiscoveryConstants.PROCESS_SERVICE_UPDATE, ServiceDiscoveryConstants.PROCESS_SERVICE_DEACTIVATE,
+                ServiceDiscoveryConstants.PROCESS_SERVICE_REMOVE };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Service service = (Service)state.getResource();
+        // 1) remove destroyed instances maps
+        List<? extends ServiceExposeMap> maps = exposeMapDao.listServiceRemovedInstancesMaps(service.getId());
+        for (ServiceExposeMap map : maps) {
+            objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, map, null);
+        }
+
+        int requestedScale = DataAccessor.field(service, ServiceDiscoveryConstants.FIELD_SCALE,
+                jsonMapper,
+                Integer.class);
+
+        // 2) scale down the service
+        if (service.getKind().equalsIgnoreCase(KIND.SERVICE.name())) {
+            sdService.scaleDownService(service, requestedScale);
+        } else if (service.getKind().equalsIgnoreCase(KIND.LOADBALANCERSERVICE.name())) {
+            sdService.scaleDownLoadBalancerService(service, requestedScale);
+        }
+
+        return null;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -39,4 +39,6 @@ public interface ServiceDiscoveryService {
 
     void scaleDownLoadBalancerService(Service service, int requestedScale);
 
+    String generateServiceInstanceName(Service service, int finalOrder);
+
 }

--- a/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
+++ b/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
@@ -12,13 +12,23 @@
         http://cattle.io/schemas/spring/extension http://cattle.io/schemas/spring/extension-1.0.xsd
         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
         
-       <bean class="io.cattle.platform.servicediscovery.process.ServiceActivate" />
+       <bean class="io.cattle.platform.servicediscovery.process.ServiceUpdateActivate" />
+       <bean class="io.cattle.platform.servicediscovery.process.ServiceCleanupPreListener" />
+       <bean class="io.cattle.platform.servicediscovery.process.ServiceUpdatePostListener" />
        <bean class="io.cattle.platform.servicediscovery.process.ServiceDeactivate" />
        <bean class="io.cattle.platform.servicediscovery.process.ServiceRemove" />
+       
        <bean class="io.cattle.platform.servicediscovery.process.EnvironmentRemove" />
-       <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryInstanceRemovePostListener" />
-       <bean class="io.cattle.platform.servicediscovery.process.ServiceUpdatePostListener" />
+              <bean class="io.cattle.platform.servicediscovery.process.EnvironmentUpdatePostListener" />
+       
+       <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryInstancePurgePostListener" />
        <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryInstanceStartPostListener" />
+       
+       <bean class="io.cattle.platform.servicediscovery.process.LoadBalancerServiceCreate" />
+       <bean class="io.cattle.platform.servicediscovery.process.LoadBalancerServiceRemove" />
+       <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerRemovePostListener" />
+       <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerTargetAddPostListener" />
+       <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerTargetRemovePostListener" />
 
        <bean class="io.cattle.platform.servicediscovery.api.action.EnvironmentExportConfigActionHandler" />
        <bean class="io.cattle.platform.servicediscovery.api.action.RemoveServiceLinkActionHandler" />
@@ -26,22 +36,28 @@
        <bean class="io.cattle.platform.servicediscovery.api.action.SetServiceLinksActionHandler" />
        <bean class="io.cattle.platform.servicediscovery.api.action.EnvironmentActivateServicesActionHandler" />
        <bean class="io.cattle.platform.servicediscovery.api.action.EnvironmentDeactivateServicesActionHandler" />
-       <bean class="io.cattle.platform.servicediscovery.dao.impl.ServiceConsumeMapDaoImpl" />
-       <bean class="io.cattle.platform.servicediscovery.service.impl.ServiceDiscoveryServiceImpl" />
-       <bean class="io.cattle.platform.servicediscovery.dao.impl.ServiceExposeMapDaoImpl" />
        <bean class="io.cattle.platform.servicediscovery.api.action.EnvironmentComposeLinkHandler" />
        
+       <bean class="io.cattle.platform.servicediscovery.dao.impl.ServiceConsumeMapDaoImpl" />
+       <bean class="io.cattle.platform.servicediscovery.dao.impl.ServiceExposeMapDaoImpl" />
+       
+       <bean class="io.cattle.platform.servicediscovery.service.impl.ServiceDiscoveryServiceImpl" />
        <bean class="io.cattle.platform.servicediscovery.service.impl.RancherImageToComposeFormatter" />
        <bean class="io.cattle.platform.servicediscovery.service.impl.RancherRestartToComposeFormatter" />
        <bean class="io.cattle.platform.servicediscovery.service.impl.RancherLoadBalancerConfigToComposeFormatter" />
 
        <bean class="io.cattle.platform.process.progress.ProcessProgressImpl" />
-       
-       <bean class="io.cattle.platform.servicediscovery.process.LoadBalancerServiceCreate" />
-       <bean class="io.cattle.platform.servicediscovery.process.LoadBalancerServiceRemove" />
-       <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerRemovePostListener" />
-       <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerTargetAddPostListener" />
-       <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerTargetRemovePostListener" />
-       
-       <bean class="io.cattle.platform.allocator.dao.impl.AllocatorDaoImpl" />
+       <bean class="io.cattle.platform.allocator.dao.impl.AllocatorDaoImpl" /> 
+
+       <tx:advice id="ServiceExposeMapDaoImplAdvice" transaction-manager="CoreTransactionManager">
+        <tx:attributes>
+            <tx:method name="createServiceInstance" isolation="READ_COMMITTED" />
+            <tx:method name="updateServiceName" isolation="READ_COMMITTED" />
+            <tx:method name="updateEnvironmentName" isolation="READ_COMMITTED" />
+        </tx:attributes>
+    </tx:advice>
+
+    <aop:config>
+        <aop:advisor advice-ref="ServiceExposeMapDaoImplAdvice" pointcut="execution(* io.cattle.platform.servicediscovery.api.dao.ServiceExposeMapDao.*(..))" />
+    </aop:config>
 </beans>

--- a/resources/content/schema/base/environment.json
+++ b/resources/content/schema/base/environment.json
@@ -3,7 +3,10 @@
         "name":{
             "required": true,
             "validChars": "[a-zA-Z0-9-]",
-            "minLength": 1
+            "minLength": 1,
+             "attributes" : {
+                "scheduleUpdate" : true
+            }
         }
     },
     "resourceActions" : {

--- a/resources/content/schema/base/service.json
+++ b/resources/content/schema/base/service.json
@@ -23,8 +23,11 @@
         },
         "name":{
             "required": true,
-            "validChars": "[a-zA-Z0-9-]",
-            "minLength": 1
+            "validChars": "[a-zA-Z0-9]-",
+            "minLength": 1,
+             "attributes" : {
+                "scheduleUpdate" : true
+            }
         },
         "launchConfig": {
             "type": "container",

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -312,7 +312,6 @@
         "environment" : "crud",
 
         "service" : "crud",
-        "service.name" : "cr",
         "service.environmentId" : "cr",
         "service.scale" : "cru",
         "service.dataVolumesFromService" : "cr",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -701,7 +701,7 @@ def test_container_events(admin_client, client, agent_client):
 
 def test_svc_discovery_service(admin_client, client):
     auth_check(admin_client.schema, 'service', 'crud', {
-        'name': 'cr',
+        'name': 'cru',
         'environmentId': 'cr',
         'scale': 'cru',
         'dataVolumesFromService': 'cr',
@@ -711,7 +711,7 @@ def test_svc_discovery_service(admin_client, client):
     })
 
     auth_check(client.schema, 'service', 'crud', {
-        'name': 'cr',
+        'name': 'cru',
         'environmentId': 'cr',
         'scale': 'cru',
         'dataVolumesFromService': 'cr',
@@ -735,7 +735,7 @@ def test_svc_discovery_environment(admin_client, client):
 
 def test_svc_discovery_lb_service(admin_client, client):
     auth_check(admin_client.schema, 'loadBalancerService', 'crud', {
-        'name': 'cr',
+        'name': 'cru',
         'environmentId': 'cr',
         'scale': 'cru',
         'dataVolumesFromService': 'cr',
@@ -746,7 +746,7 @@ def test_svc_discovery_lb_service(admin_client, client):
     })
 
     auth_check(client.schema, 'loadBalancerService', 'crud', {
-        'name': 'cr',
+        'name': 'cru',
         'environmentId': 'cr',
         'scale': 'cru',
         'dataVolumesFromService': 'cr',

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -368,14 +368,14 @@ def test_scale(admin_client, super_client):
     _wait_until_active_map_count(lb, 1, super_client)
 
     # scale up
-    service = admin_client.update(service, scale=2)
+    service = admin_client.update(service, scale=2, name=service.name)
     service = admin_client.wait_success(service, 120)
     assert service.state == "active"
     assert service.scale == 2
     _wait_until_active_map_count(lb, 2, super_client)
 
     # now scale down
-    service = admin_client.update(service, scale=0)
+    service = admin_client.update(service, scale=0, name=service.name)
     service = admin_client.wait_success(service, 120)
     assert service.state == "active"
     assert service.scale == 0


### PR DESCRIPTION
Addresses various Service Discovery bugs as well as refactored the way we handle service instance.create. Now instance and service->instance map objects get created in a single transaction. 

Bugs that should be fixed as a part of this PR:

1) When generate service instance name, take into account that existing instances might be renamed. So if the service with scale=3 has instances named:

* env_service_1
* randomName
* env_service_3

and scale up to 4 was requested, the new instance with name env_service_3 should be started

https://github.com/rancherio/rancher/issues/561
https://github.com/rancherio/rancher/issues/624

2) Don't automatically remove service-instance map when instance gets removed (as the instance can get restored)

Service link to removed instance can be removed only if activate/update operation is called on the service; or when instance gets purged.

https://github.com/rancherio/rancher/issues/527
https://github.com/rancherio/rancher/issues/570

3) Renaming environment and service should rename corresponding instances names. The name change doesn't get propagated to the backend instances till the service deactivated/activated again

https://github.com/rancherio/rancher/issues/551

4) Scale down should start stopped instances if they are within the scale

https://github.com/rancherio/rancher/issues/621