### PR TITLE
instance.stop - don't deactivate purged child objects

### DIFF
--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerInstanceRemovePostListener.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerInstanceRemovePostListener.java
@@ -57,12 +57,15 @@ public class LoadBalancerInstanceRemovePostListener extends AbstractObjectProces
     private void deleteLoadBalancerInstance(Instance instance) {
         Agent lbAgent = objectManager.loadResource(Agent.class, instance.getAgentId());
 
-        // try to remove first
-        try {
-            objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, lbAgent, null);
-        } catch (ProcessCancelException e) {
-            objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, lbAgent, ProcessUtils.chainInData(new HashMap<String, Object>(),
-                    AgentConstants.PROCESS_DEACTIVATE, AgentConstants.PROCESS_REMOVE));
+        if (lbAgent.getRemoved() == null) {
+            // try to remove first
+            try {
+                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, lbAgent, null);
+            } catch (ProcessCancelException e) {
+                objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, lbAgent,
+                        ProcessUtils.chainInData(new HashMap<String, Object>(),
+                                AgentConstants.PROCESS_DEACTIVATE, AgentConstants.PROCESS_REMOVE));
+            }
         }
     }
 

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerInstanceRemovePostListener.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerInstanceRemovePostListener.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.lb.instance.process;
 
 import io.cattle.platform.core.constants.AgentConstants;
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.LoadBalancerConstants;
 import io.cattle.platform.core.model.Agent;
@@ -56,8 +57,9 @@ public class LoadBalancerInstanceRemovePostListener extends AbstractObjectProces
 
     private void deleteLoadBalancerInstance(Instance instance) {
         Agent lbAgent = objectManager.loadResource(Agent.class, instance.getAgentId());
-
-        if (lbAgent.getRemoved() == null) {
+        if (lbAgent.getRemoved() == null
+                && !(lbAgent.getState().equalsIgnoreCase(CommonStatesConstants.REMOVED) || lbAgent.getState().equals(
+                        CommonStatesConstants.REMOVING))) {
             // try to remove first
             try {
                 objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, lbAgent, null);
@@ -68,6 +70,7 @@ public class LoadBalancerInstanceRemovePostListener extends AbstractObjectProces
             }
         }
     }
+
 
     @Override
     public int getPriority() {

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/impl/LoadBalancerInstanceManagerImpl.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/impl/LoadBalancerInstanceManagerImpl.java
@@ -3,6 +3,7 @@ package io.cattle.platform.lb.instance.service.impl;
 import io.cattle.platform.agent.instance.dao.AgentInstanceDao;
 import io.cattle.platform.agent.instance.factory.AgentInstanceFactory;
 import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.NetworkConstants;
 import io.cattle.platform.core.constants.InstanceConstants.SystemContainer;
@@ -78,10 +79,14 @@ public class LoadBalancerInstanceManagerImpl implements LoadBalancerInstanceMana
         }
 
         for (long hostId : hosts) {
+            Host host = objectManager.loadResource(Host.class, hostId);
+            if (!host.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVE)) {
+                // skip inactive host
+                continue;
+            }
             Instance lbInstance = getLoadBalancerInstance(loadBalancer, hostId);
 
             if (lbInstance == null) {
-                Host host = objectManager.loadResource(Host.class, hostId);
 
                 String imageUUID = DataAccessor.fields(loadBalancer).withKey(LoadBalancerConstants.FIELD_LB_INSTANCE_IMAGE_UUID).as(String.class);
 

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStop.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStop.java
@@ -60,7 +60,9 @@ public class InstanceStop extends AbstractDefaultProcessHandler {
         List<Volume> volumes = getObjectManager().children(instance, Volume.class);
 
         for (Volume volume : volumes) {
-            deactivate(volume, null);
+            if (volume.getRemoved() == null && !volume.getState().equals(CommonStatesConstants.REMOVED)) {
+                deactivate(volume, null);
+            }
         }
     }
 
@@ -68,7 +70,9 @@ public class InstanceStop extends AbstractDefaultProcessHandler {
         List<Nic> nics = getObjectManager().children(instance, Nic.class);
 
         for (Nic nic : nics) {
-            deactivate(nic, null);
+            if (nic.getRemoved() == null && !nic.getState().equals(CommonStatesConstants.REMOVED)) {
+                deactivate(nic, null);
+            }
         }
 
         for (Port port : getObjectManager().children(instance, Port.class)) {
@@ -78,7 +82,9 @@ public class InstanceStop extends AbstractDefaultProcessHandler {
         }
 
         for (InstanceLink link : getObjectManager().children(instance, InstanceLink.class, InstanceLinkConstants.FIELD_INSTANCE_ID)) {
-            deactivate(link, null);
+            if (link.getRemoved() == null && !link.getState().equals(CommonStatesConstants.REMOVED)) {
+                deactivate(link, null);
+            }
         }
     }
 

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -136,9 +136,8 @@ def test_deactivate_then_remove_lb_svc(super_client, admin_client):
 
     # remove service and verify that the lb is gone
     wait_success(admin_client, service.remove())
-    wait_for_condition(
-    super_client, lb, _resource_is_removed,
-    lambda x: 'State is: ' + x.state)
+    wait_for_condition(super_client, lb, _resource_is_removed,
+                       lambda x: 'State is: ' + x.state)
 
 
 def test_remove_active_lb_svc(super_client, admin_client):

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -136,9 +136,9 @@ def test_deactivate_then_remove_lb_svc(super_client, admin_client):
 
     # remove service and verify that the lb is gone
     wait_success(admin_client, service.remove())
-    lb = super_client.reload(lb)
-    lb = super_client.wait_success(lb)
-    assert lb.state == "removed"
+    wait_for_condition(
+    super_client, lb, _resource_is_removed,
+    lambda x: 'State is: ' + x.state)
 
 
 def test_remove_active_lb_svc(super_client, admin_client):
@@ -156,8 +156,9 @@ def test_remove_active_lb_svc(super_client, admin_client):
     validate_remove_host(host1, lb, super_client)
     validate_remove_host(host2, lb, super_client)
 
-    lb = super_client.reload(lb)
-    assert lb.state == "removed"
+    wait_for_condition(
+        super_client, lb, _resource_is_removed,
+        lambda x: 'State is: ' + x.state)
 
     lb_configs = super_client. \
         list_loadBalancerConfig(name=env.name + "_" + service.name)


### PR DESCRIPTION
And LB fixes

    1) fixed the tests to always wait for LB instance to come to final state,
     otherwise simulator cleanup can result in error
    2) lb.removeHost - don't trigger LB-agent instance cleanup if the host
    itself is in removing/removed state. Instance cleanup will be handled by
    generic host cleanup process where all instances on host are marked as
    removed
    3) LB config update - create LB-agent instance(s) only on active hosts