### PR TITLE
Load Balancer refactoring to work with services/new allocator

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/AccountConstraintsProvider.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/AccountConstraintsProvider.java
@@ -2,6 +2,7 @@ package io.cattle.platform.allocator.constraint;
 
 import io.cattle.platform.allocator.service.AllocationAttempt;
 import io.cattle.platform.allocator.service.AllocationLog;
+import io.cattle.platform.core.constants.InstanceConstants.SystemContainer;
 import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Volume;
@@ -24,7 +25,8 @@ public class AccountConstraintsProvider implements AllocationConstraintsProvider
         Instance instance = attempt.getInstance();
         if (instance != null) {
             //TODO: remove this condition once we have networks per user
-            if (instance.getSystemContainer() != null) {
+            if (instance.getSystemContainer() != null
+                    && instance.getSystemContainer().equalsIgnoreCase(SystemContainer.NetworkAgent.name())) {
                 return;
             }
             account = objectManager.loadResource(Account.class, instance.getAccountId());

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/dao/LoadBalancerInstanceDao.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/dao/LoadBalancerInstanceDao.java
@@ -1,9 +1,11 @@
 package io.cattle.platform.lb.instance.dao;
 
+import io.cattle.platform.core.model.LoadBalancerHostMap;
+
 import java.util.List;
 
 public interface LoadBalancerInstanceDao {
 
-    List<Long> getLoadBalancerHosts(long lbId);
+    List<? extends LoadBalancerHostMap> getLoadBalancerHostMaps(long lbId);
 
 }

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/dao/impl/LoadBalancerInstanceDaoImpl.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/dao/impl/LoadBalancerInstanceDaoImpl.java
@@ -6,7 +6,6 @@ import io.cattle.platform.core.model.LoadBalancerHostMap;
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.lb.instance.dao.LoadBalancerInstanceDao;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -17,11 +16,7 @@ public class LoadBalancerInstanceDaoImpl extends AbstractJooqDao implements Load
     GenericMapDao mapDao;
 
     @Override
-    public List<Long> getLoadBalancerHosts(long lbId) {
-        List<Long> hostIds = new ArrayList<Long>();
-        for (LoadBalancerHostMap map : mapDao.findToRemove(LoadBalancerHostMap.class, LoadBalancer.class, lbId)) {
-            hostIds.add(map.getHostId());
-        }
-        return hostIds;
+    public List<? extends LoadBalancerHostMap> getLoadBalancerHostMaps(long lbId) {
+        return mapDao.findToRemove(LoadBalancerHostMap.class, LoadBalancer.class, lbId);
     }
 }

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerInstanceHostMapActivate.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerInstanceHostMapActivate.java
@@ -1,0 +1,42 @@
+package io.cattle.platform.lb.instance.process;
+
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.InstanceHostMap;
+import io.cattle.platform.core.model.LoadBalancerHostMap;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPostListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.lb.instance.service.LoadBalancerInstanceManager;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+public class LoadBalancerInstanceHostMapActivate extends AbstractObjectProcessLogic implements ProcessPostListener {
+    @Inject
+    LoadBalancerInstanceManager lbInstanceManager;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { "instancehostmap.activate" };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        InstanceHostMap map = (InstanceHostMap) state.getResource();
+        Instance instance = objectManager.loadResource(Instance.class, map.getInstanceId());
+        if (!lbInstanceManager.isLbInstance(instance)) {
+            return null;
+        }
+        // set host id on the mapping
+        LoadBalancerHostMap hostMap = lbInstanceManager.getLoadBalancerHostMapForInstance(instance);
+        if (hostMap.getHostId() == null) {
+            hostMap.setHostId(map.getHostId());
+            objectManager.persist(hostMap);
+        }
+
+        return null;
+    }
+}

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/LoadBalancerInstanceManager.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/LoadBalancerInstanceManager.java
@@ -4,23 +4,26 @@ import io.cattle.platform.core.model.Agent;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.IpAddress;
 import io.cattle.platform.core.model.LoadBalancer;
+import io.cattle.platform.core.model.LoadBalancerHostMap;
 
 import java.util.List;
 
 public interface LoadBalancerInstanceManager {
 
-    List<? extends Instance> createLoadBalancerInstances(LoadBalancer loadBalancer, Long... hostIds);
+    List<? extends Instance> createLoadBalancerInstances(LoadBalancer loadBalancer);
 
     boolean isLbInstance(Instance instance);
 
     LoadBalancer getLoadBalancerForInstance(Instance lbInstance);
 
-    Instance getLoadBalancerInstance(LoadBalancer loadBalancer, long hostId);
+    Instance getLoadBalancerInstance(LoadBalancer loadBalancer, LoadBalancerHostMap hostMap);
 
     IpAddress getLoadBalancerInstanceIp(Instance lbInstance);
 
     List<Agent> getLoadBalancerAgents(LoadBalancer loadBalancer);
 
     List<Instance> getLoadBalancerInstances(LoadBalancer loadBalancer);
+
+    LoadBalancerHostMap getLoadBalancerHostMapForInstance(Instance lbInstance);
 
 }

--- a/code/iaas/lb-instance/src/main/resources/META-INF/cattle/system-services/spring-lb-instance-context.xml
+++ b/code/iaas/lb-instance/src/main/resources/META-INF/cattle/system-services/spring-lb-instance-context.xml
@@ -17,8 +17,9 @@
     <bean class="io.cattle.platform.lb.instance.process.LoadBalancerRemoveHostPostListener" />
     <bean class="io.cattle.platform.lb.instance.process.HostRemovePreListener" />
     <bean class="io.cattle.platform.lb.instance.process.LoadBalancerUpdateConfig" />
+    <bean class="io.cattle.platform.lb.instance.process.LoadBalancerInstanceHostMapActivate" />
+    
     <bean class="io.cattle.platform.lb.instance.dao.impl.LoadBalancerInstanceDaoImpl" />
-
     <bean class="io.cattle.platform.lb.instance.service.impl.UpdateHostLoadBalancerLookup" />
     <bean class="io.cattle.platform.lb.instance.service.impl.UpdateListenerLoadBalancerLookup" />
     <bean class="io.cattle.platform.lb.instance.service.impl.UpdateTargetLoadBalancerLookup" />

--- a/code/iaas/lb-logic/src/main/java/io/cattle/iaas/lb/service/LoadBalancerService.java
+++ b/code/iaas/lb-logic/src/main/java/io/cattle/iaas/lb/service/LoadBalancerService.java
@@ -2,12 +2,9 @@ package io.cattle.iaas.lb.service;
 
 import io.cattle.platform.core.model.LoadBalancer;
 import io.cattle.platform.core.model.LoadBalancerConfig;
+import io.cattle.platform.core.model.LoadBalancerHostMap;
 
 public interface LoadBalancerService {
-
-    void addHostToLoadBalancer(LoadBalancer lb, long hostId);
-
-    void removeHostFromLoadBalancer(LoadBalancer lb, long hostId);
 
     void addListenerToConfig(LoadBalancerConfig config, long listenerId);
 
@@ -21,4 +18,27 @@ public interface LoadBalancerService {
 
     void removeTargetIpFromLoadBalancer(LoadBalancer lb, String ipAddress);
 
+    /**
+     * adds a particular host to the load balancer
+     * 
+     * @param lb
+     * @param hostId
+     */
+    void addHostToLoadBalancer(LoadBalancer lb, long hostId);
+
+    /**
+     * requests any host to be added to the load balancer - the decision which host is delegated to allocator
+     * 
+     * @param lb
+     * @return TODO
+     */
+    LoadBalancerHostMap addHostToLoadBalancer(LoadBalancer lb);
+
+    /**
+     * removes a particular host from the load balancer
+     * 
+     * @param lb
+     * @param hostId
+     */
+    void removeHostFromLoadBalancer(LoadBalancer lb, long hostId);
 }

--- a/code/iaas/lb-logic/src/main/java/io/cattle/iaas/lb/service/impl/LoadBalancerServiceImpl.java
+++ b/code/iaas/lb-logic/src/main/java/io/cattle/iaas/lb/service/impl/LoadBalancerServiceImpl.java
@@ -129,4 +129,11 @@ public class LoadBalancerServiceImpl implements LoadBalancerService {
         }
     }
 
+    @Override
+    public LoadBalancerHostMap addHostToLoadBalancer(LoadBalancer lb) {
+        return resourceDao.createAndSchedule(LoadBalancerHostMap.class,
+                    LOAD_BALANCER_HOST_MAP.LOAD_BALANCER_ID, lb.getId(),
+                    LOAD_BALANCER_HOST_MAP.ACCOUNT_ID, lb.getAccountId());
+    }
+
 }

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.process.instance;
 
 import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.InstanceLinkConstants;
 import io.cattle.platform.core.dao.GenericMapDao;
@@ -191,7 +192,12 @@ public class InstanceStart extends AbstractDefaultProcessHandler {
 
     protected void postNetwork(Instance instance, ProcessState state) {
         for (Port port : getObjectManager().children(instance, Port.class)) {
-            activate(port, state.getData());
+            // ports can be removed while instance is still present (lb instance is an example)
+            if (port.getRemoved() == null
+                    && !(port.getState().equalsIgnoreCase(CommonStatesConstants.REMOVED) || port.getState()
+                            .equalsIgnoreCase(CommonStatesConstants.REMOVING))) {
+                activate(port, state.getData());
+            }
         }
     }
 

--- a/tests/integration/cattletest/core/test_lb_instance.py
+++ b/tests/integration/cattletest/core/test_lb_instance.py
@@ -296,12 +296,12 @@ def _create_lb_w_host(admin_client, config_id, host,
 
     # add host to lb
     lb.addhost(hostId=host.id)
-    _validate_add_host(host, lb, super_client)
+    host_map = _validate_add_host(host, lb, super_client)
 
     # verify that the agent got created
-    uri = 'sim://?lbId={}&hostId={}'. \
+    uri = 'sim://?lbId={}&hostMapId={}'. \
         format(get_plain_id(super_client, lb),
-               get_plain_id(super_client, host))
+               get_plain_id(super_client, host_map))
     agents = super_client.list_agent(uri=uri)
     assert len(agents) == 1
 
@@ -357,12 +357,108 @@ def validate_remove_host(host, lb, super_client):
     return host_map
 
 
+def _add_listener_to_config(admin_client, config, super_client):
+    listener = admin_client.create_loadBalancerListener(name=random_str(),
+                                                        sourcePort='8080',
+                                                        targetPort='80',
+                                                        sourceProtocol='http',
+                                                        targetProtocol='tcp')
+    listener = admin_client.wait_success(listener)
+    config = config.addlistener(loadBalancerListenerId=listener.id)
+    _validate_add_listener(config, listener, super_client)
+    return config, listener
+
+
+def test_validate_ports(admin_client, super_client, sim_context, nsp):
+    # using super_client here because simulator required
+    # networkId to be passed in, and this field is available
+    #  only to super_client
+    host = sim_context['host']
+
+    # create config with 1 listener
+    config = super_client. \
+        create_loadBalancerConfig(name=random_str())
+    super_client.wait_success(config)
+    config, listener = _add_listener_to_config(admin_client, config,
+                                               super_client)
+
+    # create load balancer
+    im_id = sim_context['imageUuid']
+    lb = super_client. \
+        create_loadBalancer(name=random_str(),
+                            loadBalancerConfigId=config.id,
+                            loadBalancerInstanceImageUuid=im_id,
+                            loadBalancerInstanceUriPredicate='sim://',
+                            networkId=nsp.networkId)
+    lb = super_client.wait_success(lb)
+
+    # add host to lb
+    lb.addhost(hostId=host.id)
+
+    # verify that the lb instance/host_map got created
+    host_map = _validate_add_host(host, lb, super_client)
+    uri = 'sim://?lbId={}&hostMapId={}'. \
+        format(get_plain_id(super_client, lb),
+               get_plain_id(super_client, host_map))
+    agents = super_client.list_agent(uri=uri)
+    assert len(agents) == 1
+
+    # verify that the agent instance got created
+    agent_instances = super_client.list_instance(agentId=agents[0].id)
+    assert len(agent_instances) == 1
+    instance = agent_instances[0]
+
+    # verify that the instance is set with Ports attribute
+    ports = super_client.list_port(publicPort='8080', instanceId=instance.id)
+    assert len(ports) == 1
+
+    # remove listener; make sure that the port was removed
+    listener = admin_client.wait_success(admin_client.delete(listener))
+    assert listener.state == 'removed'
+    ports = super_client.list_port(publicPort='8080', instanceId=instance.id)
+    assert len(ports) == 1
+    wait_for_condition(
+        super_client, ports[0], _resource_is_removed,
+        lambda x: 'State is: ' + x.state)
+
+    # restart the instance and verify that the port didn't appear again
+    instance = wait_success(super_client, instance.stop())
+    assert instance.state == 'stopped'
+    instance = wait_success(super_client, instance.start())
+    assert instance.state == 'running'
+    ports = super_client.list_port(publicPort='8080', instanceId=instance.id)
+    assert len(ports) == 1
+    assert ports[0].removed is not None
+
+    # re-add the listener, add target to lb
+    # and verify that the port is back in
+    image_uuid = sim_context['imageUuid']
+    container = admin_client.create_container(imageUuid=image_uuid)
+    container = admin_client.wait_success(container)
+    lb = lb.addtarget(instanceId=container.id)
+    _validate_add_target(container, lb, super_client)
+    _add_listener_to_config(admin_client, config, super_client)
+    ports = super_client.list_port(publicPort='8080', instanceId=instance.id)
+    assert len(ports) == 2
+
+
+def _validate_add_listener(config, listener, super_client):
+    lb_config_maps = super_client. \
+        list_loadBalancerConfigListenerMap(loadBalancerListenerId=listener.id,
+                                           loadBalancerConfigId=config.id)
+    assert len(lb_config_maps) == 1
+    config_map = lb_config_maps[0]
+    wait_for_condition(
+        super_client, config_map, _resource_is_active,
+        lambda x: 'State is: ' + x.state)
+
+
 def _resource_is_active(resource):
     return resource.state == 'active'
 
 
 def _resource_is_removed(resource):
-    return resource.state == 'removed'
+    return resource.state == 'removed' or resource.removed is not None
 
 
 def _validate_add_host(host, lb, super_client):
@@ -375,3 +471,15 @@ def _validate_add_host(host, lb, super_client):
         super_client, host_map, _resource_is_active,
         lambda x: 'State is: ' + x.state)
     assert host_map.hostId == host.id
+    return host_map
+
+
+def _validate_add_target(container1, lb, super_client):
+    target_maps = super_client. \
+        list_loadBalancerTarget(loadBalancerId=lb.id,
+                                instanceId=container1.id)
+    assert len(target_maps) == 1
+    target_map = target_maps[0]
+    wait_for_condition(
+        super_client, target_map, _resource_is_active,
+        lambda x: 'State is: ' + x.state)


### PR DESCRIPTION
This PR provides support for scaling up the load balancer as a part of LB service, and delegate the host picking part for haproxy instance start, to allocator. Before that user had to specify the host explicitly in loadBalancer.addHost API command (this behavior is still supported). Now you can say scale=3 on the load balancer service, and service.activate would launch 3 haproxy containers on the hosts picked by allocator, considering public ports' and other constraints. 

Implementation changes:

1) When no host is specified while scaling up the lb, record with null host_id is generated in load_balancer_host_map. Once lb instance is started on a particular host, the map is updated with that hostId.
2) LB agent uri is no longer constructed from loadBalancer/hostId. Instead its constructed from loadBalancerId/hostMapId