### PR TITLE
Service discovery bug fixes

### DIFF
--- a/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
+++ b/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
@@ -153,7 +153,7 @@
     
     <!-- Service Discovery Service/Instance map -->
     <process:process name="serviceexposemap.create" resourceType="serviceExposeMap" start="requested" transitioning="activating" done="active" />
-    <process:process name="serviceexposemap.remove" resourceType="serviceExposeMap" start="active,activating" transitioning="removing" done="removed" />
+    <process:process name="serviceexposemap.remove" resourceType="serviceExposeMap" start="active,activating, requested" transitioning="removing" done="removed" />
     
     <!-- Service Discovery Service/Service map -->
     <process:process name="serviceconsumemap.create" resourceType="serviceConsumeMap" start="requested" transitioning="activating" done="active" />

--- a/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
+++ b/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
@@ -142,14 +142,14 @@
     <!-- Service Discovery Environment -->
     <process:process name="environment.create" resourceType="environment" start="requested" transitioning="activating" done="active" />
     <process:process name="environment.update" resourceType="environment" start="active" transitioning="updating-active" done="active" />
-    <process:process name="environment.remove" resourceType="environment" start="active, activating" transitioning="removing" done="removed" />
+    <process:process name="environment.remove" resourceType="environment" start="active, activating, updating-active" transitioning="removing" done="removed" />
     
     <!-- Service Discovery Service -->
     <process:process name="service.create" resourceType="service" start="requested" transitioning="registering" done="inactive" />
     <process:process name="service.activate" resourceType="service" start="inactive" transitioning="activating" done="active" />    
     <process:process name="service.update" resourceType="service" start="inactive,active" transitioning="inactive=updating-inactive,active=updating-active" done="updating-inactive=inactive,updating-active=active" />
-    <process:process name="service.deactivate" resourceType="service" start="active,activating" transitioning="deactivating" done="inactive" />
-    <process:process name="service.remove" resourceType="service" start="inactive, registering, active,activating" transitioning="removing" done="removed" />
+    <process:process name="service.deactivate" resourceType="service" start="active,activating, updating-inactive, updating-active" transitioning="deactivating" done="inactive" />
+    <process:process name="service.remove" resourceType="service" start="inactive, registering, active, activating, updating-inactive, updating-active" transitioning="removing" done="removed" />
     
     <!-- Service Discovery Service/Instance map -->
     <process:process name="serviceexposemap.create" resourceType="serviceExposeMap" start="requested" transitioning="activating" done="active" />

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -15,6 +15,7 @@ public class ServiceDiscoveryConstants {
     public static final String FIELD_ACTIVATE_CONSUMED_SERVICES = "activateConsumedServices";
     public static final String FIELD_LAUNCH_CONFIG = "launchConfig";
     public static final String FIELD_LOAD_BALANCER_CONFIG = "loadBalancerConfig";
+    public static final String FIELD_ENVIRIONMENT_ID = "environmentId";
 
     public static final String ACTION_SERVICE_ACTIVATE = "activate";
     public static final String ACTION_SERVICE_CREATE = "create";

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/EnvironmentCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/EnvironmentCreateValidationFilter.java
@@ -1,18 +1,23 @@
 package io.cattle.platform.servicediscovery.api.filter;
 
-import static io.cattle.platform.core.model.tables.EnvironmentTable.ENVIRONMENT;
 import io.cattle.platform.core.model.Environment;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
-import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.object.meta.ObjectMetaDataManager;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
+import io.github.ibuildthecloud.gdapi.request.resource.ResourceManagerLocator;
 import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
 public class EnvironmentCreateValidationFilter extends AbstractDefaultResourceManagerFilter {
+
     @Inject
-    ObjectManager objectManager;
+    ResourceManagerLocator locator;
 
     @Override
     public Class<?>[] getTypeClasses() {
@@ -28,9 +33,13 @@ public class EnvironmentCreateValidationFilter extends AbstractDefaultResourceMa
                     "name");
         }
 
-        Environment existingEnv = objectManager.findOne(Environment.class, ENVIRONMENT.NAME, env.getName(),
-                ENVIRONMENT.REMOVED, null);
-        if (existingEnv != null) {
+        ResourceManager rm = locator.getResourceManagerByType(type);
+
+        Map<Object, Object> criteria = new HashMap<>();
+        criteria.put(ObjectMetaDataManager.NAME_FIELD, env.getName());
+        criteria.put(ObjectMetaDataManager.REMOVED_FIELD, null);
+        List<?> existingEnv = rm.list(type, criteria, null);
+        if (!existingEnv.isEmpty()) {
             ValidationErrorCodes.throwValidationError(ValidationErrorCodes.NOT_UNIQUE,
                     "name");
         }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceLoadBalancerRemoveValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceLoadBalancerRemoveValidationFilter.java
@@ -1,0 +1,34 @@
+package io.cattle.platform.servicediscovery.api.filter;
+
+import io.cattle.platform.core.model.LoadBalancer;
+import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
+import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
+import io.github.ibuildthecloud.gdapi.request.ApiRequest;
+import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
+import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
+
+import javax.inject.Inject;
+
+public class ServiceLoadBalancerRemoveValidationFilter extends AbstractDefaultResourceManagerFilter {
+
+    @Inject
+    ObjectManager objectManager;
+
+    @Override
+    public Class<?>[] getTypeClasses() {
+        return new Class<?>[] { LoadBalancer.class };
+    }
+
+    @Override
+    public Object delete(String type, String id, ApiRequest request, ResourceManager next) {
+        LoadBalancer lb = objectManager.loadResource(LoadBalancer.class, id);
+        
+        if (lb.getServiceId() != null) {
+            ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_ACTION,
+                    ServiceDiscoveryConstants.FIELD_SERVICE_ID);
+        }
+
+        return super.delete(type, id, request, next);
+    }
+}

--- a/code/iaas/service-discovery/api/src/main/resources/META-INF/cattle/api-server/spring-service-discovery-api-context.xml
+++ b/code/iaas/service-discovery/api/src/main/resources/META-INF/cattle/api-server/spring-service-discovery-api-context.xml
@@ -17,5 +17,6 @@
        <bean class="io.cattle.platform.servicediscovery.api.filter.ServiceAddRemoveLinkServiceValidationFilter" />
        <bean class="io.cattle.platform.servicediscovery.api.filter.ServiceDiscoveryEnvironmentOutputFilter" />
        <bean class="io.cattle.platform.servicediscovery.api.filter.ServiceSetServiceLinksValidationFilter" />
+       <bean class="io.cattle.platform.servicediscovery.api.filter.ServiceLoadBalancerRemoveValidationFilter" />
         
 </beans>

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryInstancePurgePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryInstancePurgePostListener.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.servicediscovery.process;
 
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.ServiceExposeMap;
 import io.cattle.platform.engine.handler.HandlerResult;
@@ -41,7 +42,10 @@ public class ServiceDiscoveryInstancePurgePostListener extends AbstractObjectPro
                 objectManager.loadResource(Instance.class, instance.getId()),
                 ServiceExposeMap.class);
         for (ServiceExposeMap map : maps) {
-            objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, map, null);
+            if (!(map.getState().equals(CommonStatesConstants.REMOVED) || map.getState().equals(
+                    CommonStatesConstants.REMOVING))) {
+                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, map, null);
+            }
         }
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryLoadBalancerTargetRemovePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryLoadBalancerTargetRemovePostListener.java
@@ -73,7 +73,11 @@ public class ServiceDiscoveryLoadBalancerTargetRemovePostListener extends Abstra
                         lbService.getId(),
                         LOAD_BALANCER.REMOVED, null);
 
-                lbManager.removeTargetFromLoadBalancer(lb, instanceServicePair.getLeft());
+                if (lb != null) {
+                    // to handle the case when link was created/removed in the short period of time while lb service is
+                    // being created
+                    lbManager.removeTargetFromLoadBalancer(lb, instanceServicePair.getLeft());
+                }
             }
         }
         return null;

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -152,7 +152,6 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
                         export = true;
                     }
                     if (export) {
-                        composeServiceData.put(item.getComposeName(), value);
                         // for every lookup, do transform
                         Object formattedValue = null;
                         for (RancherConfigToComposeFormatter formatter : formatters) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -718,6 +718,12 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
     public void scaleDownLoadBalancerService(Service service, int requestedScale) {
         LoadBalancer lb = objectManager.findOne(LoadBalancer.class, LOAD_BALANCER.SERVICE_ID, service.getId(),
                 LOAD_BALANCER.REMOVED, null);
+
+        // lb can be already removed at this point if scaleDown is called by the cleanup for service.remove process
+        if (lb == null) {
+            return;
+        }
+
         // on scale up, skip
         List<? extends LoadBalancerHostMap> existingHosts = mapDao.findNonRemoved(LoadBalancerHostMap.class,
                 LoadBalancer.class, lb.getId());

--- a/resources/content/schema/base/loadBalancerService.json
+++ b/resources/content/schema/base/loadBalancerService.json
@@ -4,7 +4,8 @@
             "type" : "string"
         },
         "loadBalancerConfig": {
-            "type" : "loadBalancerConfig"
+            "type" : "loadBalancerConfig",
+            "nullable": true
         }
     }
 }


### PR DESCRIPTION
1) Missing state transitions are added; that would fix:

https://github.com/rancherio/rancher/issues/678
https://github.com/rancherio/rancher/issues/676

2) Environment name is unique within the account, not globally

https://github.com/rancherio/rancher/issues/659

3) Disallow to remove the lb that was created as a part of LB service. This type of lb can be removed only when its service is removed

4) Don't try to scale down lb service as a part of cleanup, if the lb is gone (the cleanup is called as a part of service.remove process)

https://github.com/rancherio/rancher/issues/699

5) LB service: handle the case when consumed svc link is created before lb
    service was fully created

https://github.com/rancherio/rancher/issues/702