### PR TITLE
Fixed seting ports on lb instance

### DIFF
--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/impl/LoadBalancerInstanceManagerImpl.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/impl/LoadBalancerInstanceManagerImpl.java
@@ -240,7 +240,7 @@ public class LoadBalancerInstanceManagerImpl implements LoadBalancerInstanceMana
                 .getLoadBalancerConfigId());
         List<String> ports = new ArrayList<String>();
         for (LoadBalancerListener listener : listeners) {
-            String fullPort = listener.getSourcePort() + ":" + listener.getTargetPort();
+            String fullPort = listener.getSourcePort() + ":" + listener.getSourcePort();
             ports.add(fullPort);
         }
 


### PR DESCRIPTION
for the lb instance the public port and source port are always = to the source port specified on the lb listener. The target port of the lb listener is the one that is set for the instance lb is balancing