### PR TITLE
Service Discovery: set label on service containers

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -44,4 +44,6 @@ public class ServiceDiscoveryConstants {
     public static final String LINK_RANCHER_COMPOSE_CONFIG = "rancherComposeConfig";
     public static final String LINK_COMPOSE_CONFIG = "composeConfig";
 
+    public static final String LABEL_SERVICE_NAME = "io.rancher.service.name";
+
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceExposeMapDaoImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceExposeMapDaoImpl.java
@@ -20,7 +20,6 @@ import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 import javax.inject.Inject;
 
@@ -74,11 +73,10 @@ public class ServiceExposeMapDaoImpl extends AbstractJooqDao implements ServiceE
         final Instance instance = objectManager.create(Instance.class, props);
         objectManager.create(ServiceExposeMap.class, SERVICE_EXPOSE_MAP.INSTANCE_ID, instance.getId(),
                 SERVICE_EXPOSE_MAP.SERVICE_ID, service.getId());
-        DeferredUtils.nest(new Callable<Object>() {
+        DeferredUtils.nest(new Runnable() {
             @Override
-            public Object call() throws Exception {
+            public void run() {
                 objectProcessManager.scheduleStandardProcess(StandardProcess.CREATE, instance, null);
-                return null;
             }
         });
         return objectManager.reload(instance);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceCreate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceCreate.java
@@ -21,6 +21,7 @@ import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants.KIND;
+import io.cattle.platform.servicediscovery.resource.ServiceDiscoveryConfigItem;
 import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
 
 import java.util.HashMap;
@@ -102,6 +103,11 @@ public class LoadBalancerServiceCreate extends AbstractObjectProcessHandler {
                             .withDefault("delegate:///").as(
                                     String.class));
             data.put("accountId", service.getAccountId());
+
+            Map<String, String> labelsStr = sdService.getServiceInstanceLabels(service);
+            launchConfigData.put(ServiceDiscoveryConfigItem.LABELS.getRancherName(), labelsStr);
+
+            data.put(ServiceDiscoveryConstants.FIELD_LAUNCH_CONFIG, launchConfigData);
             lb = objectManager.create(LoadBalancer.class, data);
         }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/resource/ServiceDiscoveryConfigItem.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/resource/ServiceDiscoveryConfigItem.java
@@ -64,6 +64,9 @@ public class ServiceDiscoveryConfigItem {
             ServiceDiscoveryConstants.FIELD_LOAD_BALANCER_CONFIG, ServiceDiscoveryConstants.FIELD_LOAD_BALANCER_CONFIG,
             false, false);
 
+    public static final ServiceDiscoveryConfigItem LABELS = new ServiceDiscoveryConfigItem(
+            InstanceConstants.FIELD_LABELS, InstanceConstants.FIELD_LABELS,
+            true, false);
 
     /**
      * Name as it appears in docker-compose file

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -41,4 +41,6 @@ public interface ServiceDiscoveryService {
 
     String generateServiceInstanceName(Service service, int finalOrder);
 
+    Map<String, String> getServiceInstanceLabels(Service service);
+
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -299,7 +299,7 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
         for (String key : data.keySet()) {
             ServiceDiscoveryConfigItem item = ServiceDiscoveryConfigItem.getServiceConfigItemByRancherName(key);
             if (item != null && item.isLaunchConfigItem()) {
-                // special handling for volumesFromService
+                // special handling for volumesFromService and labels
                 if (item.getRancherName().equals(ServiceDiscoveryConfigItem.VOLUMESFROMSERVICE.getRancherName())) {
                     List<Integer> serviceIds = (List<Integer>) data.get(key);
                     for (Integer serviceId : serviceIds) {
@@ -317,6 +317,9 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
             }
         }
 
+        Map<String, String> labelsStr = getServiceInstanceLabels(service);
+        launchConfigItems.put(ServiceDiscoveryConfigItem.LABELS.getRancherName(), labelsStr);
+
         if (!volumesFromServices.isEmpty()) {
             List<Integer> volumesFrom = (List<Integer>) launchConfigItems.get(ServiceDiscoveryConfigItem.VOLUMESFROM
                     .getRancherName());
@@ -329,6 +332,19 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
         }
 
         return launchConfigItems;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<String, String> getServiceInstanceLabels(Service service) {
+        Map<String, Object> data = getServiceDataAsMap(service);
+        Object labels = data.get(ServiceDiscoveryConfigItem.LABELS.getRancherName());
+        Map<String, String> labelsStr = new HashMap<>();
+        if (labels != null) {
+            labelsStr.putAll((HashMap<String, String>) labels);
+        }
+        labelsStr.put(ServiceDiscoveryConstants.LABEL_SERVICE_NAME, service.getName());
+        return labelsStr;
     }
 
     private String getInstanceName(Instance instance) {


### PR DESCRIPTION
As a part of this PR:

1) "labels" field (Map<String, String>) is introduced on the "container" object. So labels can be set through this field on per standalone container basis, as well as on the services' containers as their launchConfig is of type "container". All affinity rules user defines in the compose, get translated into lables on launchConfig. Expected format: "affinity:container_label:io.rancher.service==name of the service you want to have an affinity with" - for affinity rules

2) When ServiceDiscovery manager builds launch data for container, it copies all labels defined on services launch config, and set them per each service container ("labels" field on the container)+ adds one more extra label with key="io.rancher.service" and value="name of the service the container belongs to"


@ibuildthecloud Darren, let me know if the above is what you expected, or if anything is missing. @will-chan suggested that we use service name, not uuid for defining the service container. The reason is - at the moment compose file is defined, user doesn't know service's uuid, only name; so we stick to name so we don't have to do any name to uuid translation

@sonchang Son, let me know if the format for labeling the service container (key="io.rancher.service" and value=<name of the service the container belongs to>) is what the allocator expects. 