### PR TITLE
Service discovery bug fixes

### DIFF
--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
@@ -6,7 +6,7 @@ agent.instance.start.items.increment=agent-instance-startup
 
 agent.instance.services.base.items=${agent.instance.start.items.apply},${agent.instance.start.items.increment}
 
-agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create
+agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.remove
 
 nic.activate.agentInstanceProvider.base.items=true
 
@@ -43,5 +43,7 @@ host.ipassociation.deactivate.agentInstanceProvider.hostNatGatewayService.increm
 
 serviceconsumemap.create.agentInstanceProvider.dnsService.apply=hosts
 serviceconsumemap.create.agentInstanceProvider.dnsService.increment=hosts
+serviceconsumemap.remove.agentInstanceProvider.dnsService.apply=hosts
+serviceconsumemap.remove.agentInstanceProvider.dnsService.increment=hosts
 serviceexposemap.create.agentInstanceProvider.dnsService.apply=hosts
 serviceexposemap.create.agentInstanceProvider.dnsService.increment=hosts

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
@@ -10,6 +10,7 @@ import static io.cattle.platform.core.model.tables.ServiceExposeMapTable.SERVICE
 import static io.cattle.platform.core.model.tables.ServiceTable.SERVICE;
 import io.cattle.platform.configitem.context.dao.DnsInfoDao;
 import io.cattle.platform.configitem.context.data.DnsEntryData;
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.IpAddressConstants;
 import io.cattle.platform.core.model.Instance;
@@ -167,6 +168,8 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
                         .and(clientNic.REMOVED.isNull())
                         .and(targetNic.REMOVED.isNull())
                         .and(serviceConsumeMap.REMOVED.isNull())
+                        .and(serviceConsumeMap.STATE.in(CommonStatesConstants.ACTIVATING,
+                                CommonStatesConstants.ACTIVE))
                         .and(clientServiceExposeMap.REMOVED.isNull())
                         .and(targetServiceExposeMap.REMOVED.isNull())
                         .and(targetService.REMOVED.isNull())

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
@@ -32,7 +32,6 @@ import io.cattle.platform.lock.LockCallbackNoReturn;
 import io.cattle.platform.lock.LockManager;
 import io.cattle.platform.object.resource.ResourceMonitor;
 import io.cattle.platform.object.resource.ResourcePredicate;
-import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.object.util.DataUtils;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
 import io.cattle.platform.util.type.Priority;
@@ -47,8 +46,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-
-import org.jooq.tools.StringUtils;
 
 import com.netflix.config.DynamicStringListProperty;
 

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/impl/LoadBalancerInstanceManagerImpl.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/impl/LoadBalancerInstanceManagerImpl.java
@@ -172,16 +172,6 @@ public class LoadBalancerInstanceManagerImpl implements LoadBalancerInstanceMana
         return instances;
     }
 
-    private List<LoadBalancerHostMap> populateHostMaps(LoadBalancer loadBalancer, LoadBalancerHostMap... hostMaps) {
-        List<LoadBalancerHostMap> hosts = new ArrayList<>();
-        if (hostMaps.length == 0) {
-            hosts.addAll(lbInstanceDao.getLoadBalancerHostMaps(loadBalancer.getId()));
-        } else {
-            hosts.addAll(Arrays.asList(hostMaps));
-        }
-        return hosts;
-    }
-
     protected void start(final Instance agentInstance) {
         if (InstanceConstants.STATE_STOPPED.equals(agentInstance.getState())) {
             DeferredUtils.nest(new Callable<Object>() {

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/EnvironmentCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/EnvironmentCreateValidationFilter.java
@@ -3,6 +3,8 @@ package io.cattle.platform.servicediscovery.api.filter;
 import io.cattle.platform.core.model.Environment;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
 import io.cattle.platform.object.meta.ObjectMetaDataManager;
+import io.github.ibuildthecloud.gdapi.condition.Condition;
+import io.github.ibuildthecloud.gdapi.condition.ConditionType;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManagerLocator;
@@ -37,7 +39,7 @@ public class EnvironmentCreateValidationFilter extends AbstractDefaultResourceMa
 
         Map<Object, Object> criteria = new HashMap<>();
         criteria.put(ObjectMetaDataManager.NAME_FIELD, env.getName());
-        criteria.put(ObjectMetaDataManager.REMOVED_FIELD, null);
+        criteria.put(ObjectMetaDataManager.REMOVED_FIELD, new Condition(ConditionType.NULL));
         List<?> existingEnv = rm.list(type, criteria, null);
         if (!existingEnv.isEmpty()) {
             ValidationErrorCodes.throwValidationError(ValidationErrorCodes.NOT_UNIQUE,

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
@@ -4,6 +4,8 @@ import io.cattle.platform.core.model.Service;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
 import io.cattle.platform.object.meta.ObjectMetaDataManager;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
+import io.github.ibuildthecloud.gdapi.condition.Condition;
+import io.github.ibuildthecloud.gdapi.condition.ConditionType;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManagerLocator;
@@ -33,7 +35,7 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
 
         Map<Object, Object> criteria = new HashMap<>();
         criteria.put(ObjectMetaDataManager.NAME_FIELD, service.getName());
-        criteria.put(ObjectMetaDataManager.REMOVED_FIELD, null);
+        criteria.put(ObjectMetaDataManager.REMOVED_FIELD, new Condition(ConditionType.NULL));
         criteria.put(ServiceDiscoveryConstants.FIELD_ENVIRIONMENT_ID, service.getEnvironmentId());
 
         List<?> existingSvcs = rm.list(type, criteria, null);

--- a/tests/integration/cattletest/core/test_lb_instance.py
+++ b/tests/integration/cattletest/core/test_lb_instance.py
@@ -326,24 +326,6 @@ def _verify_host_map_cleanup(admin_client, host,
         instance = admin_client.wait_success(instances[0])
         assert instance.state == 'removed'
 
-    # verify that the agent is gone
-    _wait_until_agent_removed(uri, super_client)
-
-
-def _wait_until_agent_removed(uri, super_client, timeout=30):
-    # need this function because agent state changes
-    # active->deactivating->removed
-    start = time.time()
-    agent = super_client.list_agent(uri=uri)[0]
-    agent = super_client.wait_success(agent)
-    while agent.state != 'removed':
-        time.sleep(.5)
-        agent = super_client.reload(agent)
-        if time.time() - start > timeout:
-            assert 'Timeout waiting for agent to be removed.'
-
-    return agent
-
 
 def validate_remove_host(host, lb, super_client):
     host_maps = super_client. \


### PR DESCRIPTION
1)Don't remove agent when lbSystemContainer removed #424  

https://github.com/rancherio/rancher/issues/773

Resolves the bug that happens due to the incorrect lb functionality on lb instance remove. Today I remove the lb agent when the lb instance fails to start. It can lead to an error condition when AgentFactory tries to start the new instance for the agent as the previous instance failed to start, while the instance that fails to start, removes the agent. So we end up having an instance2 in Running state, while its agent is gone. I will follow the same logic for the lb agent instance as for the regular network instance - the agent will be left intact.

2) Trigger DNS update on service-service map removal

https://github.com/rancherio/rancher/issues/775

3) When validate for service/environment name uniqueness, put null as an object for removed field validation (we intend to validate only against non-removed records)