### PR TITLE
Option to skip delegation on process cancel

### DIFF
--- a/code/framework/engine/pom.xml
+++ b/code/framework/engine/pom.xml
@@ -8,6 +8,11 @@
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>
+         <dependency>
+            <groupId>io.cattle</groupId>
+            <artifactId>cattle-framework-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.cattle</groupId>
             <artifactId>cattle-framework-deferred</artifactId>

--- a/code/framework/engine/src/main/java/io/cattle/platform/engine/process/ProcessInstanceConstants.java
+++ b/code/framework/engine/src/main/java/io/cattle/platform/engine/process/ProcessInstanceConstants.java
@@ -1,0 +1,5 @@
+package io.cattle.platform.engine.process;
+
+public class ProcessInstanceConstants {
+    public static final String SKIP_DELEGATE_ON_CANCEL = "skipDelegateOnCancel";
+}

--- a/code/framework/engine/src/main/java/io/cattle/platform/engine/process/impl/DefaultProcessInstanceImpl.java
+++ b/code/framework/engine/src/main/java/io/cattle/platform/engine/process/impl/DefaultProcessInstanceImpl.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.engine.process.impl;
 
 import static io.cattle.platform.engine.process.ExitReason.*;
+import static io.cattle.platform.engine.process.ProcessInstanceConstants.*;
 import static io.cattle.platform.util.time.TimeUtils.*;
 import io.cattle.platform.async.utils.TimeoutException;
 import io.cattle.platform.deferred.util.DeferredUtils;
@@ -45,6 +46,7 @@ import io.cattle.platform.lock.exception.FailedToAcquireLockException;
 import io.cattle.platform.lock.util.LockUtils;
 import io.cattle.platform.util.exception.ExceptionUtils;
 import io.cattle.platform.util.exception.ExecutionException;
+import io.cattle.platform.util.type.CollectionUtils;
 
 import java.util.Date;
 import java.util.List;
@@ -227,6 +229,11 @@ public class DefaultProcessInstanceImpl implements ProcessInstance {
     }
 
     protected boolean shouldAbort(ProcessCancelException e) {
+        Boolean skipDelegate = (Boolean)CollectionUtils.getNestedValue(instanceContext.getState().getData(), SKIP_DELEGATE_ON_CANCEL);
+        if (skipDelegate != null && skipDelegate) {
+            return true;
+        }
+
         ProcessDefinition def = context.getProcessManager().getProcessDelegate(instanceContext.getProcessDefinition());
         if (def == null) {
             return true;

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/containerevent/ContainerEventCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/containerevent/ContainerEventCreate.java
@@ -4,6 +4,7 @@ import static io.cattle.platform.core.constants.CommonStatesConstants.*;
 import static io.cattle.platform.core.constants.ContainerEventConstants.*;
 import static io.cattle.platform.core.constants.InstanceConstants.*;
 import static io.cattle.platform.core.constants.NetworkConstants.*;
+import static io.cattle.platform.engine.process.ProcessInstanceConstants.*;
 import io.cattle.platform.archaius.util.ArchaiusUtil;
 import io.cattle.platform.core.dao.AccountDao;
 import io.cattle.platform.core.dao.InstanceDao;
@@ -121,7 +122,9 @@ public class ContainerEventCreate extends AbstractDefaultProcessHandler {
                         if (STATE_STOPPED.equals(state) || STATE_STOPPING.equals(state))
                             return null;
 
-                        objectProcessManager.scheduleProcessInstance(PROCESS_STOP, instance, makeData());
+                        Map<String, Object> data = makeData();
+                        DataAccessor.fromMap(data).withKey(SKIP_DELEGATE_ON_CANCEL).set(true);
+                        objectProcessManager.scheduleProcessInstance(PROCESS_STOP, instance, data);
                     } else if (EVENT_DESTROY.equals(status)) {
                         if (REMOVED.equals(state) || REMOVING.equals(state) || PURGED.equals(state) || PURGING.equals(state))
                             return null;
@@ -169,7 +172,7 @@ public class ContainerEventCreate extends AbstractDefaultProcessHandler {
     }
 
     public static boolean isNativeDockerStart(ProcessState state) {
-        return DataAccessor.fromMap(state.getData()).withScope(ContainerEventCreate.class).withKey(PROCESS_DATA_NO_OP).withDefault(false).as(Boolean.class);
+        return DataAccessor.fromMap(state.getData()).withKey(PROCESS_DATA_NO_OP).withDefault(false).as(Boolean.class);
     }
 
     protected Map<String, Object> makeData() {


### PR DESCRIPTION
This change adds the ability to say that you don't want a process to be delegated if it is canceled.

Here's why this is needed:
1. The "default process" implementation has the deactivate process setup to delegate to remove. 
2. If a scheduled process is cancelled, its delegate (if it has one) is automatically ran (even though the original process was cancelled).
3. With native docker container events and a short lived container, the create, start, and stop events come in to rancher rapidly. In this scenario, the intended behavior was for the stop action to simply be cancelled by the framework and effectively ignored, but since stop delegates to remove, remove is ran and the container jumps from created to removing (and then to removed).

It seems odd for deactivate (which is renamed to stop for instances) to delegate to remove. It also seems odd to immediately delegate to another process if a process is cancelled. But the fact of the matter is that a lot of things break and a lot of tests fail if we change either of those things.

So, this change allows for an override to the behavior without changing it for everything that relies on it. You can set the `skipDelegateOnCancel` option on a process's data and if the process is cancel, it will not delegate.