### PR TITLE
Dont assert initial state on ha tests.

### DIFF
--- a/tests/integration/cattletest/core/test_ha.py
+++ b/tests/integration/cattletest/core/test_ha.py
@@ -10,7 +10,6 @@ def test_container_ha_default(client, super_client, user_sim_context):
                                 requestedHostId=user_sim_context['host'].id,
                                 name='simForgetImmediately')
     c = client.wait_success(c)
-    assert c.state == 'running'
 
     def do_ping():
         ping = one(super_client.list_task, name='agent.ping')
@@ -39,7 +38,6 @@ def test_container_ha_stop(super_client, sim_context):
                                       systemContainer='NetworkAgent',
                                       data={'simForgetImmediately': True})
     c = super_client.wait_success(c)
-    assert c.state == 'running'
 
     def do_ping():
         ping = one(super_client.list_task, name='agent.ping')


### PR DESCRIPTION
We should assert that contianers are running initially in test_ha.py
because the ping logic may have already gotten to them and stopped them.