### PR TITLE
LbhostMap.remove: cleanup lb instance AND lb agent

### DIFF
--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/LoadBalancerInstanceManager.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/LoadBalancerInstanceManager.java
@@ -26,4 +26,6 @@ public interface LoadBalancerInstanceManager {
 
     LoadBalancerHostMap getLoadBalancerHostMapForInstance(Instance lbInstance);
 
+    Agent getLoadBalancerAgent(LoadBalancer loadBalancer, LoadBalancerHostMap hostMap);
+
 }

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/impl/LoadBalancerInstanceManagerImpl.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/impl/LoadBalancerInstanceManagerImpl.java
@@ -147,7 +147,8 @@ public class LoadBalancerInstanceManagerImpl implements LoadBalancerInstanceMana
         return lbInstance;
     }
 
-    protected Agent getLoadBalancerAgent(LoadBalancer loadBalancer, LoadBalancerHostMap hostMap) {
+    @Override
+    public Agent getLoadBalancerAgent(LoadBalancer loadBalancer, LoadBalancerHostMap hostMap) {
         String uri = getUri(loadBalancer, hostMap);
         Agent lbAgent = agentInstanceDao.getAgentByUri(uri);
         return lbAgent;

--- a/tests/integration/cattletest/core/test_lb_instance.py
+++ b/tests/integration/cattletest/core/test_lb_instance.py
@@ -326,6 +326,24 @@ def _verify_host_map_cleanup(admin_client, host,
         instance = admin_client.wait_success(instances[0])
         assert instance.state == 'removed'
 
+    # verify that the agent is gone
+    _wait_until_agent_removed(uri, super_client)
+
+
+def _wait_until_agent_removed(uri, super_client, timeout=30):
+    # need this function because agent state changes
+    # active->deactivating->removed
+    start = time.time()
+    agent = super_client.list_agent(uri=uri)[0]
+    agent = super_client.wait_success(agent)
+    while agent.state != 'removed':
+        time.sleep(.5)
+        agent = super_client.reload(agent)
+        if time.time() - start > timeout:
+            assert 'Timeout waiting for agent to be removed.'
+
+    return agent
+
 
 def validate_remove_host(host, lb, super_client):
     host_maps = super_client. \


### PR DESCRIPTION
@ibuildthecloud Darren, this PR fixes the error you've seen on your setup happening on LoadBalancerService removal:

[p.a.s.c.i.AgentConnectionManagerImpl] Creating connection to agent [4] [delegate:///?lbId=2&hostMapId=2] 
2015-05-15 22:18:56,561 INFO  [0f54b87c-d87c-4650-a65b-d92b6be2fa5b:1267] [agent:4] [agent.reconnect->(AgentActivate)] [] [utorService-494] [a.c.d.AgentDelegateConnectionFactory] Failed to find instance to delegate to for agent [4] uri [delegate:///?lbId=2&hostMapId=2] 