### PR TITLE
Don't process docker create events

### DIFF
--- a/code/iaas/ha/src/main/java/io/cattle/platform/ha/monitor/impl/PingInstancesMonitorImpl.java
+++ b/code/iaas/ha/src/main/java/io/cattle/platform/ha/monitor/impl/PingInstancesMonitorImpl.java
@@ -192,7 +192,7 @@ public class PingInstancesMonitorImpl implements PingInstancesMonitor {
                 }
                 continue;
             }
-            addSyncAction(needsSynced, syncActions, ri, EVENT_CREATE, checkOnly);
+            addSyncAction(needsSynced, syncActions, ri, EVENT_START, checkOnly);
         }
 
         // Anything left in inRancher is in rancher, but not on the host.

--- a/code/iaas/ha/src/test/java/io/cattle/platform/ha/monitor/impl/PingInstancesMonitorImplTest.java
+++ b/code/iaas/ha/src/test/java/io/cattle/platform/ha/monitor/impl/PingInstancesMonitorImplTest.java
@@ -155,14 +155,14 @@ public class PingInstancesMonitorImplTest {
         String uuidZ = uuid("rancher-removed-host-stopped", false, false);
 
         // Container doesn't exist in rancher, running on host
-        String externalIdAA = setupSync("rancher-notexist-host-running", false, false, null, STATE_RUNNING); // no-op create
-        String externalIdBB = setupSync("rancher-notexist-host-running", true, false, null, STATE_RUNNING); // no-op create
+        String externalIdAA = setupSync("rancher-notexist-host-running", false, false, null, STATE_RUNNING); // no-op start
+        String externalIdBB = setupSync("rancher-notexist-host-running", true, false, null, STATE_RUNNING); // no-op start
         String externalIdCC = setupSync("rancher-notexist-host-running", false, true, null, STATE_RUNNING); // sysCon: force stop
         String externalIdDD = setupSync("rancher-notexist-host-running", true, true, null, STATE_RUNNING); // sysCon: force stop
 
-        // Container doesn't exist in rancher, stopped on host
-        String externalIdEE = setupSync("rancher-notexist-host-stopped", false, false, null, STATE_STOPPED); // no-op create
-        String externalIdFF = setupSync("rancher-notexist-host-stopped", true, false, null, STATE_STOPPED); // no-op create
+        // Container doesn't exist in rancher, stopped on host. User containers will be created via no-op start and be stopped in subsequent ping
+        String externalIdEE = setupSync("rancher-notexist-host-stopped", false, false, null, STATE_STOPPED); // no-op start
+        String externalIdFF = setupSync("rancher-notexist-host-stopped", true, false, null, STATE_STOPPED); // no-op start
         String externalIdGG = setupSync("rancher-notexist-host-stopped", false, true, null, STATE_STOPPED); // sysCon: do nothing
         String uuidGG = uuid("rancher-notexist-host-stopped", false, true);
         String externalIdHH = setupSync("rancher-notexist-host-stopped", true, true, null, STATE_STOPPED); // sysCon: do nothing
@@ -210,13 +210,13 @@ public class PingInstancesMonitorImplTest {
         assertDoNothing(externalIdY, uuidY);
         assertDoNothing(externalIdZ, uuidZ);
         
-        assertSyncAction(externalIdAA, EVENT_CREATE);
-        assertSyncAction(externalIdBB, EVENT_CREATE);
+        assertSyncAction(externalIdAA, EVENT_START);
+        assertSyncAction(externalIdBB, EVENT_START);
         assertSyncAction(externalIdCC, EVENT_INSTANCE_FORCE_STOP);
         assertSyncAction(externalIdDD, EVENT_INSTANCE_FORCE_STOP);
         
-        assertSyncAction(externalIdEE, EVENT_CREATE);
-        assertSyncAction(externalIdFF, EVENT_CREATE);
+        assertSyncAction(externalIdEE, EVENT_START);
+        assertSyncAction(externalIdFF, EVENT_START);
         assertDoNothing(externalIdGG, uuidGG);
         assertDoNothing(externalIdHH, uuidHH);
     }

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/containerevent/ContainerEventCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/containerevent/ContainerEventCreate.java
@@ -97,7 +97,7 @@ public class ContainerEventCreate extends AbstractDefaultProcessHandler {
 
                 try {
                     String status = event.getExternalStatus();
-                    if (status.equals(EVENT_CREATE) && instance == null) {
+                    if (status.equals(EVENT_START) && instance == null) {
                         scheduleInstance(event, instance, inspect, data);
                         return null;
                     }
@@ -169,7 +169,7 @@ public class ContainerEventCreate extends AbstractDefaultProcessHandler {
     }
 
     public static boolean isNativeDockerStart(ProcessState state) {
-        return DataAccessor.fromMap(state.getData()).withScope(ContainerEventCreate.class).withKey(PROCESS_DATA_NO_OP).withDefault(false).as(Boolean.class);
+        return DataAccessor.fromMap(state.getData()).withKey(PROCESS_DATA_NO_OP).withDefault(false).as(Boolean.class);
     }
 
     protected Map<String, Object> makeData() {

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ContainerEventConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ContainerEventConstants.java
@@ -2,7 +2,6 @@ package io.cattle.platform.core.constants;
 
 
 public class ContainerEventConstants {
-    public static final String EVENT_CREATE = "create";
     public static final String EVENT_STOP = "stop";
     public static final String EVENT_START = "start";
     public static final String EVENT_DIE = "die";


### PR DESCRIPTION
Wait until a start event is received to create a container. This will
let us always no the container's ip address when creating it, which we
use to determine its rancher network settings.