### PR TITLE
SD:Propagate labels defined in launchConfig

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -8,7 +8,6 @@ import io.cattle.platform.core.model.Service;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl.DeploymentServiceContext;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,7 +28,7 @@ public abstract class DeploymentUnitInstance {
         this.context = context;
         this.uuid = uuid;
         this.service = service;
-        this.labels = new HashMap<>();
+        this.labels = context.sdService.getServiceLabels(service);
         if (this.service != null) {
             this.labels.put(ServiceDiscoveryConstants.LABEL_SERVICE_NAME, this.service.getName());
             this.labels.put(ServiceDiscoveryConstants.LABEL_ENVIRONMENT_NAME,

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1166,19 +1166,19 @@ def test_validate_labels(super_client, admin_client, sim_context, nsp):
     assert service2.state == "active"
 
     # check that labels defined in launch config + the internal label, are set
-    result_labels_1 = {'affinity': "container==B", '!affinity': "container==C",
+    result_labels_1 = {'affinity': 'container==B', '!affinity': "container==C",
                        'io.rancher.service.name': service_name1,
                        'io.rancher.environment.name': env.name}
     instance1 = _validate_compose_instance_start(super_client, service1,
                                                  env, "1")
-    all(item in instance1.labels for item in result_labels_1)
+    assert all(item in instance1.labels for item in result_labels_1) is True
 
     # check that only one internal label is set
     result_labels_2 = {'io.rancher.service.name': service_name2,
                        'io.rancher.environment.name': env.name}
     instance2 = _validate_compose_instance_start(super_client, service2,
                                                  env, "1")
-    all(item in instance2.labels for item in result_labels_2)
+    assert all(item in instance2.labels for item in result_labels_2) is True
 
 
 def test_sidekick_services_activate(super_client,

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -426,7 +426,8 @@ def test_labels(super_client, admin_client, sim_context, nsp):
     result_labels = {'affinity': "container==B", '!affinity': "container==C",
                      'io.rancher.service.name': service_name}
 
-    all(item in lb_instance.labels.items() for item in result_labels.items())
+    assert all(item in lb_instance.labels.items()
+               for item in result_labels.items()) is True
 
     # create service w/o labels, and validate that
     #  only one service label was set
@@ -450,7 +451,8 @@ def test_labels(super_client, admin_client, sim_context, nsp):
                                                 ['8089:8089', '914:914'])
     lb_instance = _validate_lb_instance(host, lb, super_client, service)
     result_labels = {'io.rancher.service.name': service_name}
-    all(item in lb_instance.labels.items() for item in result_labels.items())
+    assert all(item in lb_instance.labels.items()
+               for item in result_labels.items()) is True
 
 
 def _wait_until_active_map_count(lb, count, super_client, timeout=30):


### PR DESCRIPTION
Fixes the bug when labels defined in service launch config, weren't propagated to the service instance along with the labels generated by the service internally 