### PR TITLE
Service Discovery bug fixes

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
@@ -59,7 +59,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
     @Inject
     ServiceConsumeMapDao consumeMapDao;
 
-    Map<Service, DeploymentUnitInstanceIdGenerator> svcInstanceIdGenerator = new HashMap<>();
+    Map<Long, DeploymentUnitInstanceIdGenerator> svcInstanceIdGenerator = new HashMap<>();
 
     @Override
     public void activate(final Service service, final Map<String, Object> data) {
@@ -156,18 +156,18 @@ public class DeploymentManagerImpl implements DeploymentManager {
          */
 
         List<DeploymentUnit> deploymentUnits = new ArrayList<>();
-        Map<String, Map<Service, DeploymentUnitInstance>> uuidToInstances = new HashMap<>();
+        Map<String, Map<Long, DeploymentUnitInstance>> uuidToInstances = new HashMap<>();
         for (Service service : services) {
             List<DeploymentUnitInstance> deploymentUnitInstances = unitInstanceFactory
                     .collectServiceInstances(service, new DeploymentServiceContext());
             
             // group by uuid
             for (DeploymentUnitInstance deploymentUnitInstance : deploymentUnitInstances) {
-                Map<Service, DeploymentUnitInstance> serviceToInstanceMap = new HashMap<>();
+                Map<Long, DeploymentUnitInstance> serviceToInstanceMap = new HashMap<>();
                 if (uuidToInstances.get(deploymentUnitInstance.getUuid()) != null) {
                     serviceToInstanceMap = uuidToInstances.get(deploymentUnitInstance.getUuid());
                 }
-                serviceToInstanceMap.put(deploymentUnitInstance.getService(), deploymentUnitInstance);
+                serviceToInstanceMap.put(deploymentUnitInstance.getService().getId(), deploymentUnitInstance);
                 uuidToInstances.put(deploymentUnitInstance.getUuid(), serviceToInstanceMap);
             }
         }
@@ -213,7 +213,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
         for (Service service : services) {
             List<Integer> usedNames = sdSvc.getServiceInstanceUsedOrderIds(service);
             svcInstanceIdGenerator
-                    .put(service,
+                    .put(service.getId(),
                             new DeploymentUnitInstanceIdGeneratorImpl(objectMgr.loadResource(
                                     Environment.class, service.getEnvironmentId()), service, usedNames));
         }


### PR DESCRIPTION
1) LBService: restart instance if stopped on activate
https://github.com/rancherio/rancher/issues/844

2) Check if service referenced via volumesFrom, still exists before resolving the instanceIds

https://github.com/rancherio/rancher/issues/849

3) Always wait for instance referenced via volumesFrom, to be fully started before creating a referencing instance. Otherwise the parameter might be ignored on the docker side.

https://github.com/rancherio/rancher/issues/846

And one more fix not corresponding to any bug - store used service generated instance names in map with key=serviceId instead of key=service. If we do the latter, the same DB object can be stored multiple times in the map, and it will grow fast.
