### PR TITLE
Make ContainerEventCreate survive null inspect

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/containerevent/ContainerEventCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/containerevent/ContainerEventCreate.java
@@ -162,10 +162,7 @@ public class ContainerEventCreate extends AbstractDefaultProcessHandler {
     }
 
     Map<String, Object> getInspect(ContainerEvent event) {
-        Object obj = DataUtils.getFields(event).get(FIELD_DOCKER_INSPECT);
-        if (obj == null)
-            return null;
-        return CollectionUtils.toMap(obj);
+        return CollectionUtils.toMap(DataUtils.getFields(event).get(FIELD_DOCKER_INSPECT));
     }
 
     public static boolean isNativeDockerStart(ProcessState state) {
@@ -185,9 +182,10 @@ public class ContainerEventCreate extends AbstractDefaultProcessHandler {
     void setName(Map<String, Object> inspect, Map<String, Object> data, Instance instance) {
         String name = DataAccessor.fromMap(data).withKey(CONTAINER_EVENT_SYNC_NAME).as(String.class);
         if (StringUtils.isEmpty(name))
-            name = (String)inspect.get(INSPECT_NAME);
+            name = DataAccessor.fromMap(inspect).withKey(INSPECT_NAME).as(String.class);
 
-        name = name.replaceFirst("/", "");
+        if (name != null)
+            name = name.replaceFirst("/", "");
         instance.setName(name);
     }
 
@@ -231,9 +229,6 @@ public class ContainerEventCreate extends AbstractDefaultProcessHandler {
     }
 
     String getDockerIp(Map<String, Object> inspect) {
-        if (inspect == null)
-            return null;
-
         Object ip = CollectionUtils.getNestedValue(inspect, "NetworkSettings", "IPAddress");
         if (ip != null)
             return ip.toString();
@@ -277,10 +272,7 @@ public class ContainerEventCreate extends AbstractDefaultProcessHandler {
         if (StringUtils.isNotEmpty(label))
             return label;
 
-        if (inspect == null)
-            return null;
-
-        Map<String, Object> config = (Map<String, Object>)inspect.get(INSPECT_CONFIG);
+        Map<String, Object> config = CollectionUtils.toMap(inspect.get(INSPECT_CONFIG));
 
         Map<String, String> labels = CollectionUtils.toMap(config.get(INSPECT_LABELS));
         label = labels.get(labelKey);

--- a/tests/integration/cattletest/core/test_container_event.py
+++ b/tests/integration/cattletest/core/test_container_event.py
@@ -180,6 +180,23 @@ def test_bad_host(user_sim_context, new_sim_context):
     assert e.value.error.code == 'InvalidReference'
 
 
+def test_container_event_null_inspect(client, user_sim_context, user_account):
+    # Assert that the inspect can be null.
+    host, agent_cli = sim_agent_and_host(user_sim_context)
+    external_id = random_str()
+    user_id = user_account.id
+
+    create_event(host, external_id, agent_cli, client, user_id,
+                 'start', None)
+
+    def container_wait():
+        containers = client.list_container(externalId=external_id)
+        if len(containers) and containers[0].state != 'requested':
+            return containers[0]
+    container = wait_for(container_wait)
+    assert container is not None
+
+
 def test_requested_ip_address(super_client, client, user_sim_context,
                               user_account):
     create_agent_instance_nsp(super_client, user_sim_context)


### PR DESCRIPTION
ContainerEventCreate relied on inspect being not null for no good reason. This change makes it possible for dockerInspect to be null without causing ContainerEventCreate to blow and keep getting retried forever.