### PR TITLE
Handle unfound host for agent better in ping

### DIFF
--- a/code/iaas/agent-server/src/main/resources/META-INF/cattle/agent-server/defaults.properties
+++ b/code/iaas/agent-server/src/main/resources/META-INF/cattle/agent-server/defaults.properties
@@ -7,6 +7,7 @@ agent.ping.unmanaged.every=12
 agent.ping.stats.every=60
 # 1 minute
 agent.ping.resources.every=12
+# 5 seconds
 agent.ping.instances.every=1
 
 agent.ping.reconnect.after.failed.count=6


### PR DESCRIPTION
LoadingCache doesn't allow null values. If you want to indicate that a
value could not be found for your key, you must raise (and handle) an exception.

The returned value can be null if a ping occurs between an agent responds to an instance ping before the host has been created.