### PR TITLE
Service discovery bug fixes

### DIFF
--- a/code/framework/object/src/main/java/io/cattle/platform/object/process/ObjectProcessManager.java
+++ b/code/framework/object/src/main/java/io/cattle/platform/object/process/ObjectProcessManager.java
@@ -25,4 +25,8 @@ public interface ObjectProcessManager {
 
     ExitReason executeProcess(String processName, Object resource, Map<String, Object> data);
 
+    void scheduleProcessInstanceAsync(String processName, Object resource, Map<String, Object> data);
+
+    void scheduleStandardProcessAsync(StandardProcess process, Object resource, Map<String, Object> data);
+
 }

--- a/code/framework/object/src/main/java/io/cattle/platform/object/process/impl/DefaultObjectProcessManager.java
+++ b/code/framework/object/src/main/java/io/cattle/platform/object/process/impl/DefaultObjectProcessManager.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.object.process.impl;
 
+import io.cattle.platform.deferred.util.DeferredUtils;
 import io.cattle.platform.engine.manager.ProcessManager;
 import io.cattle.platform.engine.process.ExitReason;
 import io.cattle.platform.engine.process.LaunchConfiguration;
@@ -103,5 +104,27 @@ public class DefaultObjectProcessManager implements ObjectProcessManager {
     public ExitReason executeProcess(String processName, Object resource, Map<String, Object> data) {
         ProcessInstance pi = createProcessInstance(processName, resource, data);
         return pi.execute();
+    }
+
+    @Override
+    public void scheduleProcessInstanceAsync(final String processName, final Object resource,
+            final Map<String, Object> data) {
+        DeferredUtils.nest(new Runnable() {
+            @Override
+            public void run() {
+                scheduleProcessInstance(processName, resource, data);
+            }
+        });
+    }
+
+    @Override
+    public void scheduleStandardProcessAsync(final StandardProcess process, final Object resource,
+            final Map<String, Object> data) {
+        DeferredUtils.nest(new Runnable() {
+            @Override
+            public void run() {
+                scheduleStandardProcess(process, resource, data);
+            }
+        });
     }
 }

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/dao/LoadBalancerInstanceDao.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/dao/LoadBalancerInstanceDao.java
@@ -8,4 +8,5 @@ public interface LoadBalancerInstanceDao {
 
     List<? extends LoadBalancerHostMap> getLoadBalancerHostMaps(long lbId);
 
+    List<? extends LoadBalancerHostMap> getNonRemovedLoadBalancerHostMaps(long lbId);
 }

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/dao/impl/LoadBalancerInstanceDaoImpl.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/dao/impl/LoadBalancerInstanceDaoImpl.java
@@ -19,4 +19,9 @@ public class LoadBalancerInstanceDaoImpl extends AbstractJooqDao implements Load
     public List<? extends LoadBalancerHostMap> getLoadBalancerHostMaps(long lbId) {
         return mapDao.findToRemove(LoadBalancerHostMap.class, LoadBalancer.class, lbId);
     }
+
+    @Override
+    public List<? extends LoadBalancerHostMap> getNonRemovedLoadBalancerHostMaps(long lbId) {
+        return mapDao.findNonRemoved(LoadBalancerHostMap.class, LoadBalancer.class, lbId);
+    }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
@@ -122,6 +122,7 @@ public class DeploymentUnit {
                     volumesFromUnitInstance = createInstance(volumesFromUnitInstance.getService().getId());
                 }
                 // wait for start
+                volumesFromUnitInstance.start(new ArrayList<Integer>());
                 volumesFromUnitInstance.waitForStart();
                 volumesFromInstanceIds.add(volumesFromUnitInstance.getInstance().getId().intValue());
             }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnitInstanceIdGeneratorImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnitInstanceIdGeneratorImpl.java
@@ -35,7 +35,7 @@ public class DeploymentUnitInstanceIdGeneratorImpl implements DeploymentUnitInst
             // in situation when service with scale=3 has one container missing (it got destroyed outside of the
             // service)
             // and container names don't reflect the order, we should pick the least available number that is <=order
-            for (int i = 1; i < usedIds.size(); i++) {
+            for (int i = 1; i <= usedIds.size(); i++) {
                 if (!usedIds.contains(i)) {
                     idToReturn = i;
                     break;

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -299,7 +299,11 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
             if (volumesFrom == null) {
                 volumesFrom = new ArrayList<Integer>();
             }
-            volumesFrom.addAll(volumesFromInstanceIds);
+            for (Integer volumesFromInstanceId : volumesFromInstanceIds) {
+                if (!volumesFrom.contains(volumesFromInstanceId)) {
+                    volumesFrom.add(volumesFromInstanceId);
+                }
+            }
             launchConfigItems.put(ServiceDiscoveryConfigItem.VOLUMESFROM.getCattleName(), volumesFrom);
         }
 

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -12,7 +12,6 @@ def create_env_and_svc(client, context):
 
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
-                                    networkId=nsp.networkId,
                                     launchConfig=launch_config)
     service = client.wait_success(service)
     assert service.state == "inactive"


### PR DESCRIPTION
1) Set dataVolumes for LB service

https://github.com/rancherio/rancher/issues/861

2) Start instances referred by volumesFrom (if exist, but not running)

https://github.com/rancherio/rancher/issues/860

3) Fixed bug when LoadBalancer instance manager was creating the agent for removed hostMap. We should exclude those maps from the logic

4) In ServiceDiscovery code, schedule all processes through DeferredUtils so the event is published immediately. In this way the process will get picked faster for execution. 