### PR TITLE
Convert test_ha to use wait_for_condition

### DIFF
--- a/tests/integration/cattletest/core/test_ha.py
+++ b/tests/integration/cattletest/core/test_ha.py
@@ -23,8 +23,12 @@ def test_container_ha_default(super_client, new_context):
 
     processes = wait_for(callback)
 
-    c = client.wait_success(c)
+    c = wait_for_condition(client, c,
+                           lambda x: x.state == 'stopped',
+                           lambda x: 'State is: ' + x.state)
 
+    # TODO Remove this debugging block once we've seen this test not fail for
+    # a few weeks. So, anytime after 6/4/2015.
     if c.state != 'stopped':
         logging.warn('test_container_ha_default debugging')
         for p in processes:
@@ -32,7 +36,6 @@ def test_container_ha_default(super_client, new_context):
             for pe in process_executions(super_client, p.id):
                 logging.warn('ProcessExecution: %s' % pe)
 
-    assert c.state == 'stopped'
     assert _process_names(processes) == {'instance.create', 'instance.stop'}
 
 
@@ -54,8 +57,9 @@ def test_container_ha_stop(super_client, new_context):
 
     processes = wait_for(callback)
 
-    c = super_client.wait_success(c)
-    assert c.state == 'stopped'
+    wait_for_condition(super_client, c,
+                       lambda x: x.state == 'stopped',
+                       lambda x: 'State is: ' + x.state)
 
     assert _process_names(processes) == {'instance.create',
                                          'instance.restart',
@@ -81,8 +85,9 @@ def test_container_ha_restart(super_client, new_context):
 
     processes = wait_for(callback)
 
-    c = super_client.wait_success(c)
-    assert c.state == 'running'
+    wait_for_condition(super_client, c,
+                       lambda x: x.state == 'running',
+                       lambda x: 'State is: ' + x.state)
 
     assert _process_names(processes) == {'instance.create',
                                          'instance.restart',
@@ -109,8 +114,9 @@ def test_container_ha_remove(super_client, new_context):
 
     processes = wait_for(callback)
 
-    c = super_client.wait_success(c)
-    assert c.state == 'removed'
+    wait_for_condition(super_client, c,
+                       lambda x: x.state == 'removed',
+                       lambda x: 'State is: ' + x.state)
 
     assert _process_names(processes) == {'instance.create',
                                          'instance.restart',


### PR DESCRIPTION
With idempotent.checks=true, these tests have a race condition wherein the ha action that we're testing for may not have been successfully scheduled by the time wait_success is called. So, we should switch to wait_for_condition to allow the ha action to be scheduled.

While we only see this issue inconsistently in drone, the issue can be perfectly and consistently reproduced with this change:
https://github.com/cjellick/cattle/commit/d9df4a02d5f48f26ea9266595f757e2e770c1378

So, the issue is that when the `instance.stop` process is first requested, the idempotency checks cause that to be retried. At this point, the instance has not yet been moved to "stopping". But, `instance.stop` is now in the process list and [in the test](https://github.com/rancherio/cattle/blob/master/tests/integration/cattletest/core/test_ha.py#L19-L26) we assume that if it is in the process list, then the instance must be transitioning to stopped (ie, transitioning=true, and state=stopping). In fact, the instance is still in the state 'running', so wait_success immediately returns and `assert c.state == 'stopped' fails.

Here's the debug logs we added to the test for a failed run.*
https://gist.github.com/cjellick/6d593aee4c7b88082f3d
The logs show the container's processInstances and their process executions. You can see that we have:
* 1 instance.create processInstance
* 1 processExecution for the above processInstance
* 1 processInstance for instance.stop, ***but no processExecution for this instance.stop***, which further proves the race condition

*Note that the processExecution for instance.create is incredibly long. You don't really need to look at it. The important thing is that there is no processExecution for instance.stop