### PR TITLE
Schedule instance.remove on account/host purge

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/account/AccountPurge.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/account/AccountPurge.java
@@ -11,10 +11,11 @@ import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
 import io.cattle.platform.engine.process.impl.ProcessCancelException;
 import io.cattle.platform.object.process.StandardProcess;
-import io.cattle.platform.object.util.ObjectUtils;
 import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
+import io.cattle.platform.util.type.CollectionUtils;
 
 import java.util.Map;
+
 import javax.inject.Named;
 
 @Named
@@ -58,12 +59,11 @@ public class AccountPurge extends AbstractDefaultProcessHandler {
             }
 
             try {
-                objectProcessManager.executeProcess(InstanceConstants.PROCESS_STOP, instance, null);
+                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, instance, null);
             } catch (ProcessCancelException e) {
-                // ignore
+                objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_STOP, instance,
+                        CollectionUtils.asMap(InstanceConstants.REMOVE_OPTION, true));
             }
-
-            remove(instance, null);
         }
 
         return null;

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/host/HostPurge.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/host/HostPurge.java
@@ -12,7 +12,9 @@ import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
 import io.cattle.platform.engine.process.impl.ProcessCancelException;
+import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
+import io.cattle.platform.util.type.CollectionUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -63,11 +65,11 @@ public class HostPurge extends AbstractDefaultProcessHandler {
 
         for (Instance instance : instanceDao.getNonRemovedInstanceOn(host.getId())) {
             try {
-                execute(InstanceConstants.PROCESS_STOP, instance, state.getData());
+                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, instance, null);
             } catch (ProcessCancelException e) {
-                // ignore
+                objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_STOP, instance,
+                        CollectionUtils.asMap(InstanceConstants.REMOVE_OPTION, true));
             }
-            remove(instance, state.getData());
         }
 
         return null;


### PR DESCRIPTION
Using execute for instance.remove leads to idempotency failures because
of how we set the removed fields while the instance is still in
the "removing" state and then make a check against the removed field when
determing which instances to remove.