### PR TITLE
Don't blindly reset data fields on setTransitioning

### DIFF
--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/generic/GenericResourceProcessState.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/generic/GenericResourceProcessState.java
@@ -15,6 +15,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,9 +72,14 @@ public class GenericResourceProcessState extends AbstractStatesBasedProcessState
     @Override
     protected boolean setState(boolean transitioning, String oldState, String newState) {
         if (resource != null && transitioning && ObjectMetaDataManager.STATE_FIELD.equals(getStatesDefinition().getStateField())) {
-            DataAccessor.fields(resource).withKey(ObjectMetaDataManager.TRANSITIONING_FIELD).remove();
+            DataAccessor field = DataAccessor.fields(resource).withKey(ObjectMetaDataManager.TRANSITIONING_FIELD);
+            DataAccessor message = DataAccessor.fields(resource).withKey(ObjectMetaDataManager.TRANSITIONING_MESSAGE_FIELD);
 
-            DataAccessor.fields(resource).withKey(ObjectMetaDataManager.TRANSITIONING_MESSAGE_FIELD).remove();
+            for (DataAccessor accessor : new DataAccessor[] {field, message}) {
+                if (StringUtils.isNotBlank(accessor.as(String.class))) {
+                    accessor.remove();
+                }
+            }
         }
 
         Object newResource = objectManager.setFields(resource, getStatesDefinition().getStateField(), newState);

--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/account/DockerAccountCreate.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/account/DockerAccountCreate.java
@@ -110,6 +110,9 @@ public class DockerAccountCreate extends AbstractObjectProcessLogic implements P
     protected Network createNetwork(String kind, Account account, Map<String, Network> networksByKind,
                                   String name, String key, Object... valueKeyValue) {
         Network network = networksByKind.get(kind);
+        if (network != null) {
+            return network;
+        }
         Map<String, Object> data = key == null ? new HashMap<String, Object>() :
                 CollectionUtils.asMap(key, valueKeyValue);
 
@@ -117,13 +120,7 @@ public class DockerAccountCreate extends AbstractObjectProcessLogic implements P
         data.put(ObjectMetaDataManager.ACCOUNT_FIELD, account.getId());
         data.put(ObjectMetaDataManager.KIND_FIELD, kind);
 
-        if (network == null) {
-            network = resourceDao.createAndSchedule(Network.class, data);
-        } else {
-            network = objectManager.setFields(network, data);
-        }
-
-        return network;
+        return resourceDao.createAndSchedule(Network.class, data);
     }
 
     protected Map<String, NetworkService> collectionNetworkServices(Network network) {


### PR DESCRIPTION
When setting transitioning we clear the transitioning and
transitioningMessage fields in the data field.  We should not blindly
remove it when they were never set because the forces an optimistic DB
lock that is not needed.