### PR TITLE
Fix reconnect logic

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentActivate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentActivate.java
@@ -37,8 +37,8 @@ public class AgentActivate extends AbstractDefaultProcessHandler {
         boolean waitFor = DataAccessor.fromDataFieldOf(agent)
                 .withScope(AgentActivate.class)
                 .withKey("waitForPing")
-                .withDefault(Boolean.FALSE)
-                .as(Boolean.class);
+                .withDefault(process.getName().equals(AgentConstants.PROCESS_RECONNECT))
+                        .as(Boolean.class);
 
         RemoteAgent remoteAgent = agentLocator.lookupAgent(agent);
         ListenableFuture<? extends Event> future = remoteAgent.call(AgentUtils.newPing(agent)


### PR DESCRIPTION
Previously agent.reconnect would block waiting for a successful ping.
That logic was change to background the ping.  This caused an
applification of pings as more reconnect processes we're scheduled and
more pings were background.  We now have switch the logic back to
waiting for a ping on reconnect.