### PR TITLE
Labels backpopulate and tranform

### DIFF
--- a/code/implementation/docker/compute/pom.xml
+++ b/code/implementation/docker/compute/pom.xml
@@ -28,5 +28,10 @@
             <artifactId>cattle-framework-jooq</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.cattle</groupId>
+            <artifactId>cattle-iaas-labels</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
@@ -119,10 +119,9 @@ public class DockerPostInstanceHostMapActivate extends AbstractObjectProcessLogi
         return null;
     }
 
-    @SuppressWarnings({ "unchecked" })
     void processLabels(Instance instance) {
-        Map<String, String> labels = (Map<String, String>)CollectionUtils.getNestedValue(instance.getData(), FIELD_DOCKER_INSPECT, "Config",
-                "Labels");
+        Map<String, String> labels = CollectionUtils.toMap(CollectionUtils.getNestedValue(instance.getData(), FIELD_DOCKER_INSPECT, "Config",
+                "Labels"));
         for (Map.Entry<String, String>label : labels.entrySet()) {
             labelsService.createContainerLabel(instance.getAccountId(), instance.getId(), label.getKey(), label.getValue());
         }

--- a/tests/integration/cattletest/core/resources/inspect_full.json
+++ b/tests/integration/cattletest/core/resources/inspect_full.json
@@ -30,6 +30,10 @@
         },
         "Hostname": "ahostname",
         "Image": "busybox",
+        "Labels": {
+          "io.rancher.labeltest.value": "val",
+          "io.rancher.labeltest.blank": ""
+        },
         "MacAddress": "",
         "Memory": 4194304,
         "MemorySwap": 0,

--- a/tests/integration/cattletest/core/resources/roundtrip_container.json
+++ b/tests/integration/cattletest/core/resources/roundtrip_container.json
@@ -156,6 +156,9 @@
     "name": "on-failure"
   },
   "startOnCreate": true,
+  "labels": {
+    "io.rancher.labeltest.value": "val"
+  },
   "stdinOpen": false,
   "systemContainer": null,
   "token": "9uKx0H8520ikSHnvY9qoDRQ1VMMNW5HxcYeQpAuCG4159MHth8CXJgiRTKMj9loi1qGFFW36YHqtZjovQ63fA",

--- a/tests/integration/cattletest/core/resources/roundtrip_inspect.json
+++ b/tests/integration/cattletest/core/resources/roundtrip_inspect.json
@@ -33,6 +33,9 @@
         "CpuShares": 1024,
         "Domainname": "example.com",
         "Image": "ubuntu:14.04.1",
+        "Labels": {
+          "io.rancher.labeltest.value": "val"
+        },
         "ExposedPorts": null
       },
       "HostsPath": "/mnt/sda1/var/lib/docker/containers/30ad6d9ca7238f6d0e6e311e6487368596855725bd87629353ac1bcf5487d8c3/hosts",

--- a/tests/integration/cattletest/core/test_transform_inspect.py
+++ b/tests/integration/cattletest/core/test_transform_inspect.py
@@ -46,6 +46,7 @@ def test_transform_inspect_minimal(transform_url, client):
     assert len(container['capDrop']) == 0
     assert container['restartPolicy'] is None
     assert len(container['devices']) == 0
+    assert len(container['labels']) == 0
 
 
 def test_transform_inspect_full(transform_url, client, super_client):
@@ -94,6 +95,9 @@ def test_transform_inspect_full(transform_url, client, super_client):
     assert restart_pol['maximumRetryCount'] == 10
     assert len(container['devices']) == 1
     assert '/dev/null:/dev/xnull:rwm' in container['devices']
+    assert len(container['labels']) == 2
+    assert container['labels']['io.rancher.labeltest.value'] == 'val'
+    assert container['labels']['io.rancher.labeltest.blank'] == ''
 
     # Load with admin so that we can see the data field
     response = requests.post(transform_url, inspect,
@@ -108,6 +112,8 @@ def test_transform_inspect_full(transform_url, client, super_client):
 
 
 def test_transform_inspect_rountrip(transform_url, client):
+    # Asserts that the container json returned by the transform api matches
+    # the json for a container created in rancher
     inspect = inspect_payload('roundtrip_inspect.json')
     response = requests.post(transform_url, inspect,
                              auth=HTTPBasicAuth(client._access_key,
@@ -156,6 +162,7 @@ def test_transform_inspect_rountrip(transform_url, client):
     assert container['capDrop'] == orig_container['capDrop']
     assert container['restartPolicy'] == orig_container['restartPolicy']
     assert container['devices'] == orig_container['devices']
+    assert container['labels'] == orig_container['labels']
 
 
 def inspect_payload(name):


### PR DESCRIPTION
Backpopulate rancher labels with all docker labels reported in the inspect after the container is started.
Add label support to the inspect transtormer api.