### PR TITLE
src IP rewrite rules keyed off of dnsService now

### DIFF
--- a/resources/content/config-content/iptables/content-home/etc/cattle/iptables-save.ftl
+++ b/resources/content/config-content/iptables/content-home/etc/cattle/iptables-save.ftl
@@ -49,12 +49,12 @@ COMMIT
 
 -A POSTROUTING -o ${primaryNic} -m mark --mark 100 -j MASQUERADE
 
-<#if serviceSet?seq_contains("metadataService") >
-    <#list services["metadataService"].nicNames as nic >
+<#if serviceSet?seq_contains("dnsService") >
+    <#list services["dnsService"].nicNames as nic >
 -A PREROUTING -p tcp -m addrtype --dst-type LOCAL --dport 80 -i ${nic} -j DNAT --to :8080
         <#list vnetClients as vnetClient >
             <#if (vnetClient.ipAddress)?? && (vnetClient.macAddress)?? >
-# Metadata mapping
+# Force incoming to traffic to the right IP
 -A INPUT -m mac --mac-source ${vnetClient.macAddress} -p tcp -m addrtype --dst-type LOCAL -i ${nic} -j SNAT --to-source ${vnetClient.ipAddress}
             </#if>
 


### PR DESCRIPTION
metadataService was removed, but these rules are still needed for
dnsService so we key off of those now.