### PR TITLE
Not null check for sourceIp when generate dns config

### DIFF
--- a/resources/content/config-content/hosts/content-home/etc/cattle/dns/answers.json.ftl
+++ b/resources/content/config-content/hosts/content-home/etc/cattle/dns/answers.json.ftl
@@ -6,7 +6,7 @@
     },
 <#if dnsEntries?? >
     <#list dnsEntries as dnsEntry>
-        <#if dnsEntry.resolve?has_content>
+        <#if dnsEntry.resolve?has_content && dnsEntry.sourceIpAddress.address??>
     "${dnsEntry.sourceIpAddress.address}": {
             <#if (dnsEntry.instance.data.fields.dns)?? && dnsEntry.instance.data.fields.dns?has_content >
         "recurse": [


### PR DESCRIPTION
Fix for the config error seen a couple of times on Drone:

evaluated to null or missing:
==> dnsEntry.sourceIpAddress.address  [in template "jar:injar:jar___file___/var/cache/drone/src/github.com/rancherio/cattle/code/packaging/app/target/cattle-app-0.5.0-SNAPSHOT.war__/WEB-INF/lib/cattle-resources-0.5.0-SNAPSHOT.jar!/config-content/hosts/content-home/etc/cattle/dns/answers.json.ftl" at line 10, column 8]

Tip: If the failing expression is known to be legally null/missing, either specify a default value with myOptionalVar!myDefault, or use <#if myOptionalVar??>when-present<#else>when-missing</#if>. (These only cover the last step of the expression; to cover the whole expression, use parenthessis: (myOptionVar.foo)!myDefault, (myOptionVar.foo)??

The failing instruction:
==> ${dnsEntry.sourceIpAddress.address}  [in template "jar:injar:jar___file___/var/cache/drone/src/github.com/rancherio/cattle/code/packaging/app/target/cattle-app-0.5.0-SNAPSHOT.war__/WEB-INF/lib/cattle-resources-0.5.0-SNAPSHOT.jar!/config-content/hosts/content-home/etc/cattle/dns/answers.json.ftl" at line 10, column 6]