### PR TITLE
update the syntax for affinity labels; also, fix regression

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/AffinityConstraintDefinition.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/AffinityConstraintDefinition.java
@@ -2,10 +2,10 @@ package io.cattle.platform.allocator.constraint;
 
 public class AffinityConstraintDefinition {
     public enum AffinityOps {
-        SOFT_EQ("==~", "{eq~}"),
-        SOFT_NE("!=~", "{ne~}"),
-        EQ("==", "{eq}"),
-        NE("!=", "{ne}");
+        SOFT_NE("!=~", "_soft_ne"),
+        SOFT_EQ("==~", "_soft"),
+        NE("!=", "_ne"),
+        EQ("==", "");
 
         String envSymbol;
         String labelSymbol;

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/ContainerLabelAffinityConstraint.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/ContainerLabelAffinityConstraint.java
@@ -11,7 +11,7 @@ import com.google.common.collect.Multimap;
 
 public class ContainerLabelAffinityConstraint implements Constraint {
     public static final String ENV_HEADER_AFFINITY_CONTAINER_LABEL = "affinity:container_label:";
-    public static final String LABEL_HEADER_AFFINITY_CONTAINER_LABEL = "io.rancher.scheduler." + ENV_HEADER_AFFINITY_CONTAINER_LABEL;
+    public static final String LABEL_HEADER_AFFINITY_CONTAINER_LABEL = "io.rancher.scheduler.affinity:container_label";
 
     AllocatorDao allocatorDao;
 

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/HostAffinityConstraint.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/HostAffinityConstraint.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 public class HostAffinityConstraint implements Constraint {
     public static final String ENV_HEADER_AFFINITY_HOST_LABEL = "constraint:";
-    public static final String LABEL_HEADER_AFFINITY_HOST_LABEL = "io.rancher.scheduler." + ENV_HEADER_AFFINITY_HOST_LABEL;
+    public static final String LABEL_HEADER_AFFINITY_HOST_LABEL = "io.rancher.scheduler.affinity:host_label";
 
     AllocatorDao allocatorDao;
 

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocatorService.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocatorService.java
@@ -7,12 +7,18 @@ import java.util.Map;
 
 public interface AllocatorService {
 
-    public List<Long> getHostsForGlobalService(Long accountId, Map<String, String> labels);
+    List<Long> getHostsForGlobalService(Long accountId, Map<String, String> labels);
+
+    /**
+     * Add labels from 'srcMap' to 'destMap'.  If key already exists in destMap, either
+     * overwrite or merge depending on whether the key is an affinity rule or not
+     */
+    void mergeLabels(Map<String, String> srcMap, Map<String, String> destMap);
 
     @SuppressWarnings("rawtypes")
-    public List<Constraint> extractConstraintsFromEnv(Map env);
+    List<Constraint> extractConstraintsFromEnv(Map env);
 
     @SuppressWarnings("rawtypes")
-    public List<Constraint> extractConstraintsFromLabels(Map labels);
+    List<Constraint> extractConstraintsFromLabels(Map labels);
 
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
@@ -205,11 +205,9 @@ public class DeploymentUnit {
         /*
          * Put affinity constraint on every instance to let allocator know that they should go to the same host
          */
-        labels.put(ContainerLabelAffinityConstraint.LABEL_HEADER_AFFINITY_CONTAINER_LABEL
-                + ServiceDiscoveryConstants.LABEL_SERVICE_DEPLOYMENT_UNIT + AffinityOps.SOFT_EQ.getLabelSymbol()
-                + this.uuid,
-                null);
-
+        // TODO: Might change labels into a Multimap or add a service function to handle merging
+        String containerLabelSoftAffinityKey = ContainerLabelAffinityConstraint.LABEL_HEADER_AFFINITY_CONTAINER_LABEL + AffinityOps.SOFT_EQ.getLabelSymbol();
+        labels.put(containerLabelSoftAffinityKey, ServiceDiscoveryConstants.LABEL_SERVICE_DEPLOYMENT_UNIT + "=" + this.uuid);
         labels.putAll(this.unitLabels);
 
         return labels;

--- a/tests/integration/cattletest/core/test_allocation.py
+++ b/tests/integration/cattletest/core/test_allocation.py
@@ -370,7 +370,7 @@ def test_host_affinity(super_client, new_context):
         containers.append(c)
 
         c = new_context.create_container(
-            labels={'io.rancher.scheduler.constraint:size{eq}huge': ''})
+            labels={'io.rancher.scheduler.affinity:host_label': 'size=huge'})
         assert c.hosts()[0].id == host.id
         containers.append(c)
 
@@ -381,7 +381,8 @@ def test_host_affinity(super_client, new_context):
         containers.append(c)
 
         c = new_context.create_container(
-            labels={'io.rancher.scheduler.constraint:size{ne}huge': ''})
+            labels={'io.rancher.scheduler.affinity:host_label_ne':
+                    'size=huge'})
         assert c.hosts()[0].id == host2.id
         containers.append(c)
 
@@ -397,8 +398,9 @@ def test_host_affinity(super_client, new_context):
 
         c = new_context.create_container(
             labels={
-                'io.rancher.scheduler.constraint:size{eq}huge': '',
-                'io.rancher.scheduler.constraint:latency{ne~}short': ''
+                'io.rancher.scheduler.affinity:host_label': 'size=huge',
+                'io.rancher.scheduler.affinity:host_label_soft_ne':
+                    'latency=short'
             })
         assert c.hosts()[0].id == host.id
         containers.append(c)
@@ -410,7 +412,8 @@ def test_host_affinity(super_client, new_context):
         containers.append(c)
 
         c = new_context.create_container(
-            labels={'io.rancher.scheduler.constraint:latency{ne~}long': ''})
+            labels={'io.rancher.scheduler.affinity:host_label_soft_ne':
+                    'latency=long'})
         assert c.hosts()[0].id == host2.id
         containers.append(c)
     finally:
@@ -437,7 +440,7 @@ def test_container_affinity(new_context):
         assert c2.hosts()[0].id == c1.hosts()[0].id
 
         c3 = new_context.create_container(
-            labels={'io.rancher.scheduler.affinity:container{eq}' + name1: ''})
+            labels={'io.rancher.scheduler.affinity:container': name1})
         containers.append(c3)
 
         # check c3 is on same host as c1
@@ -452,7 +455,7 @@ def test_container_affinity(new_context):
 
         c5 = new_context.create_container(
             labels={
-                'io.rancher.scheduler.affinity:container{eq}' + c1.uuid: ''})
+                'io.rancher.scheduler.affinity:container': c1.uuid})
         containers.append(c5)
 
         # check c5 is on same host as c1
@@ -466,7 +469,7 @@ def test_container_affinity(new_context):
         assert c6.hosts()[0].id != c1.hosts()[0].id
 
         c7 = new_context.create_container(
-            labels={'io.rancher.scheduler.affinity:container{ne}' + name1: ''})
+            labels={'io.rancher.scheduler.affinity:container_ne': name1})
         containers.append(c7)
 
         # check c7 is not on same host as c1
@@ -497,8 +500,8 @@ def test_container_label_affinity(new_context):
 
         c3 = new_context.create_container(
             labels={
-                'io.rancher.scheduler.affinity:container_label:foo{eq}'
-                + c1_label: ''}
+                'io.rancher.scheduler.affinity:container_label':
+                    'foo=' + c1_label}
         )
         containers.append(c3)
 
@@ -532,8 +535,8 @@ def test_container_label_affinity(new_context):
                 'affinity:container_label:foo!=' + c1_label: '',
             },
             labels={
-                'io.rancher.scheduler.affinity:container_label:foo{ne~}'
-                + c4_label: ''
+                'io.rancher.scheduler.affinity:container_label_soft_ne':
+                'foo=' + c4_label
             }
         )
         containers.append(c6)

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1510,8 +1510,8 @@ def test_service_affinity_rules(super_client, new_context):
     launch_config = {
         "imageUuid": image_uuid,
         "labels": {
-            "io.rancher.scheduler.affinity:container_label:" +
-            "io.rancher.service.name{ne}" + service_name: ""
+            "io.rancher.scheduler.affinity:container_label_ne":
+            "io.rancher.service.name=" + service_name
         }
     }
 
@@ -1538,8 +1538,8 @@ def test_service_affinity_rules(super_client, new_context):
     launch_config2 = {
         "imageUuid": image_uuid,
         "labels": {
-            "io.rancher.scheduler.affinity:container_label:" +
-            "io.rancher.service.name{eq~}" + service_name2: ""
+            "io.rancher.scheduler.affinity:container_label_soft":
+            "io.rancher.service.name=" + service_name2
         }
     }
 


### PR DESCRIPTION
There was a regression causing a TF in test_service_affinity_rules.  Basically, user's custom service labels wasn't being populated in instances.
@ibuildthecloud @alena1108 