### PR TITLE
Named service links suppport

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
@@ -17,6 +17,7 @@ import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.InstanceLink;
 import io.cattle.platform.core.model.IpAddress;
 import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceConsumeMap;
 import io.cattle.platform.core.model.ServiceExposeMap;
 import io.cattle.platform.core.model.tables.InstanceLinkTable;
 import io.cattle.platform.core.model.tables.InstanceTable;
@@ -102,6 +103,14 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
                 .fetch().map(mapper);
     }
 
+    private String getDnsName(Object serviceConsumeMap, Object service) {
+        String consumeMapName = ((ServiceConsumeMap) serviceConsumeMap).getName();
+        if (consumeMapName != null && !consumeMapName.isEmpty()) {
+            return consumeMapName;
+        }
+        return ((Service) service).getName();
+    }
+
     @Override
     public List<DnsEntryData> getServiceHostDnsData(final Instance instance) {
         MultiRecordMapper<DnsEntryData> mapper = new MultiRecordMapper<DnsEntryData>() {
@@ -111,7 +120,7 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
                 Map<String, List<String>> resolve = new HashMap<>();
                 List<String> ips = new ArrayList<>();
                 ips.add(((IpAddress) input.get(1)).getAddress());
-                resolve.put(((Service) input.get(0)).getName(), ips);
+                resolve.put(getDnsName(input.get(4), input.get(0)), ips);
                 data.setSourceIpAddress((IpAddress) input.get(2));
                 data.setResolve(resolve);
                 data.setInstance((Instance)input.get(3));
@@ -123,6 +132,7 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
         IpAddressTable targetIpAddress = mapper.add(IP_ADDRESS);
         IpAddressTable clientIpAddress = mapper.add(IP_ADDRESS);
         InstanceTable clientInstance = mapper.add(INSTANCE);
+        ServiceConsumeMapTable serviceConsumeMap = mapper.add(SERVICE_CONSUME_MAP);
         NicTable clientNic = NIC.as("client_nic");
         NicTable targetNic = NIC.as("target_nic");
         InstanceTable targetInstance = INSTANCE.as("instance");
@@ -130,7 +140,6 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
         IpAddressNicMapTable targetNicIpTable = IP_ADDRESS_NIC_MAP.as("target_nic_ip");
         ServiceExposeMapTable clientServiceExposeMap = SERVICE_EXPOSE_MAP.as("service_expose_map_client");
         ServiceExposeMapTable targetServiceExposeMap = SERVICE_EXPOSE_MAP.as("service_expose_map_target");
-        ServiceConsumeMapTable serviceConsumeMap = SERVICE_CONSUME_MAP.as("service_consume_map");
 
         return create()
                 .select(mapper.fields())
@@ -261,7 +270,7 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
                 Map<String, List<String>> resolve = new HashMap<>();
                 List<String> ips = new ArrayList<>();
                 ips.add(((ServiceExposeMap) input.get(1)).getIpAddress());
-                resolve.put(((Service) input.get(0)).getName(), ips);
+                resolve.put(getDnsName(input.get(4), input.get(0)), ips);
                 data.setSourceIpAddress((IpAddress) input.get(2));
                 data.setResolve(resolve);
                 data.setInstance((Instance) input.get(3));
@@ -273,10 +282,10 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
         ServiceExposeMapTable targetServiceExposeMap = mapper.add(SERVICE_EXPOSE_MAP);
         IpAddressTable clientIpAddress = mapper.add(IP_ADDRESS);
         InstanceTable clientInstance = mapper.add(INSTANCE);
+        ServiceConsumeMapTable serviceConsumeMap = mapper.add(SERVICE_CONSUME_MAP);
         NicTable clientNic = NIC.as("client_nic");
         IpAddressNicMapTable clientNicIpTable = IP_ADDRESS_NIC_MAP.as("client_nic_ip");
         ServiceExposeMapTable clientServiceExposeMap = SERVICE_EXPOSE_MAP.as("service_expose_map_client");
-        ServiceConsumeMapTable serviceConsumeMap = SERVICE_CONSUME_MAP.as("service_consume_map");
 
         return create()
                 .select(mapper.fields())
@@ -323,7 +332,7 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
                 Map<String, List<String>> resolve = new HashMap<>();
                 List<String> ips = new ArrayList<>();
                 ips.add(((IpAddress) input.get(1)).getAddress());
-                resolve.put(((Service) input.get(0)).getName(), ips);
+                resolve.put(getDnsName(input.get(4), input.get(0)), ips);
                 data.setSourceIpAddress((IpAddress) input.get(2));
                 data.setResolve(resolve);
                 data.setInstance((Instance) input.get(3));
@@ -335,6 +344,7 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
         IpAddressTable targetIpAddress = mapper.add(IP_ADDRESS);
         IpAddressTable clientIpAddress = mapper.add(IP_ADDRESS);
         InstanceTable clientInstance = mapper.add(INSTANCE);
+        ServiceConsumeMapTable dnsConsumeMap = mapper.add(SERVICE_CONSUME_MAP);
         NicTable clientNic = NIC.as("client_nic");
         NicTable targetNic = NIC.as("target_nic");
         InstanceTable targetInstance = INSTANCE.as("instance");
@@ -342,8 +352,7 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
         IpAddressNicMapTable targetNicIpTable = IP_ADDRESS_NIC_MAP.as("target_nic_ip");
         ServiceExposeMapTable clientServiceExposeMap = SERVICE_EXPOSE_MAP.as("service_expose_map_client");
         ServiceExposeMapTable targetServiceExposeMap = SERVICE_EXPOSE_MAP.as("service_expose_map_target");
-        ServiceConsumeMapTable dnsConsumeMap = SERVICE_CONSUME_MAP.as("dns_consume_map");
-        ServiceConsumeMapTable serviceConsumeMap = SERVICE_CONSUME_MAP.as("service_consume_map");
+        ServiceConsumeMapTable serviceConsumeMap = SERVICE_CONSUME_MAP.as("consume_map");
 
         return create()
                 .select(mapper.fields())

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -20,6 +20,8 @@ public class ServiceDiscoveryConstants {
     public static final String FIELD_ENVIRIONMENT_ID = "environmentId";
     public static final String FIELD_EXTERNALIPS = "externalIpAddresses";
     public static final String FIELD_NETWORKSERVICE = "networkServiceId";
+    public static final String FIELD_SERVICE_LINKS = "serviceLinks";
+    public static final String FIELD_SERVICE_LINK_NAME = "name";
 
     public static final String ACTION_SERVICE_ACTIVATE = "activate";
     public static final String ACTION_SERVICE_CREATE = "create";

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceSetServiceLinksValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceSetServiceLinksValidationFilter.java
@@ -3,13 +3,13 @@ package io.cattle.platform.servicediscovery.api.filter;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
 import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
-import io.cattle.platform.util.type.CollectionUtils;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
 import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -27,18 +27,19 @@ public class ServiceSetServiceLinksValidationFilter extends AbstractDefaultResou
     @Override
     public Object resourceAction(String type, ApiRequest request, ResourceManager next) {
         if (request.getAction().equals(ServiceDiscoveryConstants.ACTION_SERVICE_SET_SERVICE_LINKS)) {
-            Map<String, Object> data = CollectionUtils.toMap(request.getRequestObject());
-            validateServices(Long.valueOf(request.getId()), data, request.getAction());
+            validateServices(Long.valueOf(request.getId()), request);
         }
 
         return super.resourceAction(type, request, next);
     }
 
     @SuppressWarnings("unchecked")
-    private void validateServices(long serviceId, Map<String, Object> data, String action) {
-        List<Long> consumedServiceIds = (List<Long>) data.get(ServiceDiscoveryConstants.FIELD_SERVICE_IDS);
+    private void validateServices(long serviceId, ApiRequest request) {
+        Map<String, Long> newServiceLinks = DataAccessor.fromMap(request.getRequestObject())
+                .withKey(ServiceDiscoveryConstants.FIELD_SERVICE_LINKS).withDefault(Collections.EMPTY_MAP)
+                .as(Map.class);
         Service service = objectManager.loadResource(Service.class, serviceId);
-        for (Long consumedServiceId : consumedServiceIds) {
+        for (Long consumedServiceId : newServiceLinks.values()) {
             Service consumedService = objectManager.loadResource(Service.class, consumedServiceId);
             if (service == null || consumedService == null
                     || !consumedService.getEnvironmentId().equals(service.getEnvironmentId())) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/api/action/AddServiceLinkActionHandler.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/api/action/AddServiceLinkActionHandler.java
@@ -38,20 +38,23 @@ public class AddServiceLinkActionHandler implements ActionHandler {
         Service service = (Service) obj;
         Long consumedServiceId = DataAccessor.fromMap(request.getRequestObject())
                 .withKey(ServiceDiscoveryConstants.FIELD_SERVICE_ID).as(Long.class);
+        String linkName = DataAccessor.fromMap(request.getRequestObject())
+                .withKey(ServiceDiscoveryConstants.FIELD_SERVICE_LINK_NAME).as(String.class);
 
-        createMap(service, consumedServiceId);
+        createMap(service, consumedServiceId, linkName);
 
         return service;
     }
 
-    protected void createMap(Service service, long consumedServiceId) {
+    protected void createMap(Service service, long consumedServiceId, String name) {
         ServiceConsumeMap map = consumeMapDao.findNonRemovedMap(service.getId(), consumedServiceId);
 
         if (map == null) {
             map = objectManager.create(ServiceConsumeMap.class,
                     SERVICE_CONSUME_MAP.SERVICE_ID,
                     service.getId(), SERVICE_CONSUME_MAP.CONSUMED_SERVICE_ID, consumedServiceId,
-                    SERVICE_CONSUME_MAP.ACCOUNT_ID, service.getAccountId());
+                    SERVICE_CONSUME_MAP.ACCOUNT_ID, service.getAccountId(),
+                    SERVICE_CONSUME_MAP.NAME, name);
         }
         objectProcessManager.scheduleProcessInstance(ServiceDiscoveryConstants.PROCESS_SERVICE_CONSUME_MAP_CREATE,
                 map, null);

--- a/resources/content/schema/base/addRemoveServiceLinkInput.json
+++ b/resources/content/schema/base/addRemoveServiceLinkInput.json
@@ -5,6 +5,11 @@
             "type": "reference[service]",
             "required": true,
             "nullable": false
+        },
+        "name" : {
+            "type": "string",
+            "required": false,
+            "nullable": true
         }
     }
 }

--- a/resources/content/schema/base/setServiceLinksInput.json
+++ b/resources/content/schema/base/setServiceLinksInput.json
@@ -1,8 +1,8 @@
 {
     "collectionMethods" : [],
     "resourceFields": {
-        "serviceIds": {
-            "type": "array[reference[service]]",
+        "serviceLinks": {
+            "type": "map[reference[service]]",
             "nullable": false
         }
     }

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -352,9 +352,10 @@
 
         "addRemoveServiceLinkInput" : "r",
         "addRemoveServiceLinkInput.serviceId" : "cr",
+        "addRemoveServiceLinkInput.name" : "cr",
 
         "setServiceLinksInput" : "r",
-        "setServiceLinksInput.serviceIds" : "cr",
+        "setServiceLinksInput.serviceLinks" : "cr",
 
         "loadBalancerConfigListenerMap" : "r",
         "loadBalancerConfigListenerMap.loadBalancerConfigId" : "r",


### PR DESCRIPTION
API changes:

1) addServiceLink. New parameter "name" (optional) got added
2) setServiceLinks. "serviceIds" array is replaced with "serviceLinks" map, where key is the link name, and value is the reference to the service. Unfortunately couldn't make link name optional (by making Service a key in the map) as our API framework supports only Strings for a key

@vincent99 @ibuildthecloud please review