### PR TITLE
Wait on serviceExposeMap to be removed during reconcile cleanup

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DefaultDeploymentUnitInstance.java
@@ -15,7 +15,6 @@ import io.cattle.platform.servicediscovery.deployment.InstanceUnit;
 import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl.DeploymentServiceContext;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -45,10 +44,7 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
     }
 
     @Override
-    public void remove() {
-        // 1) schedule remove for the instance
-        // removal instance is scheduled ahead of map removal, to avoid situation when map removal is scheduled, but
-        // removal scheduling fails by some reason
+    protected void removeUnitInstance() {
         if (!(instance.getState().equals(CommonStatesConstants.REMOVED) || instance.getState().equals(
                 CommonStatesConstants.REMOVING))) {
             try {
@@ -59,14 +55,6 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
                         instance, ProcessUtils.chainInData(new HashMap<String, Object>(),
                                 InstanceConstants.PROCESS_STOP, InstanceConstants.PROCESS_REMOVE));
             }
-        }
-
-        // 2) remove the mapping
-        List<? extends ServiceExposeMap> maps = context.objectManager.mappedChildren(
-                context.objectManager.loadResource(Instance.class, instance.getId()),
-                ServiceExposeMap.class);
-        for (ServiceExposeMap map : maps) {
-            context.objectProcessManager.scheduleStandardProcessAsync(StandardProcess.REMOVE, map, null);
         }
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ExternalDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ExternalDeploymentUnitInstance.java
@@ -29,7 +29,7 @@ public class ExternalDeploymentUnitInstance extends DeploymentUnitInstance {
     }
 
     @Override
-    public void remove() {
+    protected void removeUnitInstance() {
         return;
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/LoadBalancerDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/LoadBalancerDeploymentUnitInstance.java
@@ -1,7 +1,6 @@
 package io.cattle.platform.servicediscovery.deployment.impl;
 
-import static io.cattle.platform.core.model.tables.LoadBalancerTable.*;
-
+import static io.cattle.platform.core.model.tables.LoadBalancerTable.LOAD_BALANCER;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.HealthcheckConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
@@ -10,7 +9,6 @@ import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.LoadBalancer;
 import io.cattle.platform.core.model.LoadBalancerHostMap;
 import io.cattle.platform.core.model.Service;
-import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.resource.ResourcePredicate;
 import io.cattle.platform.servicediscovery.deployment.DeploymentUnitInstance;
 import io.cattle.platform.servicediscovery.deployment.InstanceUnit;
@@ -50,15 +48,10 @@ public class LoadBalancerDeploymentUnitInstance extends DeploymentUnitInstance i
     }
 
     @Override
-    public void remove() {
-        // 1) remove host map
+    protected void removeUnitInstance() {
         context.objectProcessManager.scheduleProcessInstanceAsync(
                 LoadBalancerConstants.PROCESS_LB_HOST_MAP_REMOVE,
                 context.objectManager.reload(hostMap), null);
-        // 2) remove the mapping
-        if (this.exposeMap != null) {
-            context.objectProcessManager.scheduleStandardProcessAsync(StandardProcess.REMOVE, exposeMap, null);
-        }
     }
 
     @Override

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -1,6 +1,5 @@
 package io.cattle.platform.servicediscovery.service;
 
-import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Service;
 
 import java.util.AbstractMap.SimpleEntry;


### PR DESCRIPTION
for units in a "bad" state, before creating a new units. As the "used"
instances names generator might get wrong data based on the
serviceExposeMap that was scheduled for the removal, but wasn't removed
yet.

Should potentially fix one of the TF observed on master