### PR TITLE
Reconcile LB targets on lb service activate

### DIFF
--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
@@ -209,7 +209,7 @@ public class LoadBalancerUpdateConfig extends AbstractObjectProcessLogic impleme
             List<? extends Instance> lbInstances = lbInstancesMap.get(lbId);
             // surround by lock
             for (final Instance lbInstance : lbInstances) {
-                boolean lbHasActiveTargets = (targetDao.getLoadBalancerActiveInstanceTargets(lb.getId()).size() + targetDao
+                boolean lbHasActiveTargets = (targetDao.getLoadBalancerActiveTargetInstances(lb.getId()).size() + targetDao
                         .getLoadBalancerActiveIpTargets(lb.getId()).size()) > 0;
                 List<String> ports = DataUtils.getFieldList(lbInstance.getData(), InstanceConstants.FIELD_PORTS,
                         String.class);

--- a/code/iaas/lb-logic/src/main/java/io/cattle/iaas/lb/service/impl/LoadBalancerServiceImpl.java
+++ b/code/iaas/lb-logic/src/main/java/io/cattle/iaas/lb/service/impl/LoadBalancerServiceImpl.java
@@ -98,7 +98,7 @@ public class LoadBalancerServiceImpl implements LoadBalancerService {
                     LOAD_BALANCER_TARGET.LOAD_BALANCER_ID, lb.getId(), LOAD_BALANCER_TARGET.IP_ADDRESS, null,
                     LOAD_BALANCER_TARGET.ACCOUNT_ID, lb.getAccountId());
         }
-        objectProcessManager.scheduleProcessInstance(LoadBalancerConstants.PROCESS_LB_TARGET_MAP_CREATE,
+        objectProcessManager.scheduleProcessInstanceAsync(LoadBalancerConstants.PROCESS_LB_TARGET_MAP_CREATE,
                 target, null);
     }
 
@@ -119,7 +119,8 @@ public class LoadBalancerServiceImpl implements LoadBalancerService {
     public void removeTargetFromLoadBalancer(LoadBalancer lb, long instanceId) {
         LoadBalancerTarget target = lbTargetDao.getLbInstanceTargetToRemove(lb.getId(), instanceId);
         if (target != null) {
-            objectProcessManager.scheduleProcessInstance(LoadBalancerConstants.PROCESS_LB_TARGET_MAP_REMOVE, target,
+            objectProcessManager.scheduleProcessInstanceAsync(LoadBalancerConstants.PROCESS_LB_TARGET_MAP_REMOVE,
+                    target,
                     null);
         }
     }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/LoadBalancerTargetDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/LoadBalancerTargetDao.java
@@ -19,8 +19,10 @@ public interface LoadBalancerTargetDao {
 
     LoadBalancerTarget getLbIpAddressTargetToRemove(long lbId, String ipAddress);
 
-    List<? extends Instance> getLoadBalancerActiveInstanceTargets(long lbId);
+    List<? extends Instance> getLoadBalancerActiveTargetInstances(long lbId);
 
     List<? extends LoadBalancerTarget> getLoadBalancerActiveIpTargets(long lbId);
+
+    List<? extends LoadBalancerTarget> getLoadBalancerActiveInstanceTargets(long lbId);
 
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/LoadBalancerTargetDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/LoadBalancerTargetDaoImpl.java
@@ -83,7 +83,7 @@ public class LoadBalancerTargetDaoImpl extends AbstractJooqDao implements LoadBa
     }
 
     @Override
-    public List<? extends Instance> getLoadBalancerActiveInstanceTargets(long lbId) {
+    public List<? extends Instance> getLoadBalancerActiveTargetInstances(long lbId) {
         return create()
                 .select(INSTANCE.fields())
                 .from(INSTANCE)
@@ -108,6 +108,20 @@ public class LoadBalancerTargetDaoImpl extends AbstractJooqDao implements LoadBa
                         LOAD_BALANCER_TARGET.STATE.in(CommonStatesConstants.ACTIVATING,
                                         CommonStatesConstants.ACTIVE))
                         .and(LOAD_BALANCER_TARGET.IP_ADDRESS.isNotNull())
+                        .and(LOAD_BALANCER_TARGET.LOAD_BALANCER_ID.eq(lbId)))
+                .fetchInto(LoadBalancerTargetRecord.class);
+    }
+
+    @Override
+    public List<? extends LoadBalancerTarget> getLoadBalancerActiveInstanceTargets(long lbId) {
+        return create()
+                .select(LOAD_BALANCER_TARGET.fields())
+                .from(LOAD_BALANCER_TARGET)
+                .where(LOAD_BALANCER_TARGET.REMOVED.isNull()
+                        .and(
+                                LOAD_BALANCER_TARGET.STATE.in(CommonStatesConstants.ACTIVATING,
+                                        CommonStatesConstants.ACTIVE))
+                        .and(LOAD_BALANCER_TARGET.INSTANCE_ID.isNotNull())
                         .and(LOAD_BALANCER_TARGET.LOAD_BALANCER_ID.eq(lbId)))
                 .fetchInto(LoadBalancerTargetRecord.class);
     }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceActivatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceActivatePostListener.java
@@ -1,0 +1,120 @@
+package io.cattle.platform.servicediscovery.process;
+
+import static io.cattle.platform.core.model.tables.LoadBalancerTable.LOAD_BALANCER;
+import io.cattle.iaas.lb.service.LoadBalancerService;
+import io.cattle.platform.core.dao.LoadBalancerTargetDao;
+import io.cattle.platform.core.model.LoadBalancer;
+import io.cattle.platform.core.model.LoadBalancerTarget;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceConsumeMap;
+import io.cattle.platform.core.model.ServiceExposeMap;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPostListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
+import io.cattle.platform.servicediscovery.api.dao.ServiceConsumeMapDao;
+import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
+import io.cattle.platform.util.type.Priority;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class LoadBalancerServiceActivatePostListener extends AbstractObjectProcessLogic implements ProcessPostListener,
+        Priority {
+
+    @Inject
+    ServiceDiscoveryService sdService;
+
+    @Inject
+    LoadBalancerTargetDao targetDao;
+
+    @Inject
+    ServiceConsumeMapDao consumeMapDao;
+
+    @Inject
+    LoadBalancerService lbService;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { ServiceDiscoveryConstants.PROCESS_SERVICE_ACTIVATE };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Service service = (Service) state.getResource();
+        if (!service.getKind().equalsIgnoreCase(ServiceDiscoveryConstants.KIND.LOADBALANCERSERVICE.name())) {
+            return null;
+        }
+        
+        LoadBalancer lb = objectManager.findOne(LoadBalancer.class, LOAD_BALANCER.SERVICE_ID,
+                service.getId(), LOAD_BALANCER.REMOVED, null);
+        
+        List<Long> consumedInstancesIds = getConsumedInstancesIds(service);
+        List<Long> lbTargetIds = getLoadBalancerTargetInstancesIds(lb);
+
+        addMissingTargets(lb, consumedInstancesIds, lbTargetIds);
+        removeExtraTargets(lb, consumedInstancesIds, lbTargetIds);
+
+        return null;
+    }
+
+    protected void removeExtraTargets(LoadBalancer lb, List<Long> consumedInstancesIds, List<Long> lbTargetIds) {
+        List<Long> targetInstancesToRemove = new ArrayList<>();
+        targetInstancesToRemove.addAll(lbTargetIds);
+        targetInstancesToRemove.removeAll(consumedInstancesIds);
+        for (Long toRemove : targetInstancesToRemove) {
+            lbService.removeTargetFromLoadBalancer(lb, toRemove);
+        }
+    }
+
+    protected void addMissingTargets(LoadBalancer lb, List<Long> consumedInstancesIds, List<Long> lbTargetIds) {
+        List<Long> targetInstanceToAdd = new ArrayList<>();
+        targetInstanceToAdd.addAll(consumedInstancesIds);
+        targetInstanceToAdd.removeAll(lbTargetIds);
+
+        for (Long toAdd : targetInstanceToAdd) {
+            lbService.addTargetToLoadBalancer(lb, toAdd);
+        }
+    }
+
+    protected List<Long> getConsumedInstancesIds(Service service) {
+        List<Long> consumedInstancesIds = new ArrayList<>();
+        // a) get all the services consumed by the lb service
+        List<? extends ServiceConsumeMap> consumedServicesMaps = consumeMapDao.findConsumedServices(service
+                .getId());
+        // b) for every service, get the instances and register them as lb targets
+        for (ServiceConsumeMap consumedServiceMap : consumedServicesMaps) {
+            List<? extends ServiceExposeMap> maps = objectManager.mappedChildren(
+                    objectManager.loadResource(Service.class, consumedServiceMap.getConsumedServiceId()),
+                    ServiceExposeMap.class);
+            for (ServiceExposeMap map : maps) {
+                if (map.getInstanceId() != null) {
+                    consumedInstancesIds.add(map.getInstanceId());
+                }
+            }
+        }
+        return consumedInstancesIds;
+    }
+    
+    protected List<Long> getLoadBalancerTargetInstancesIds(LoadBalancer lb) {
+        List<Long> targetIds = new ArrayList<>();
+        List<? extends LoadBalancerTarget> lbTargets = targetDao.getLoadBalancerActiveInstanceTargets(lb.getId());
+        for (LoadBalancerTarget lbTarget : lbTargets) {
+            if (lbTarget.getInstanceId() != null) {
+                targetIds.add(lbTarget.getInstanceId());
+            }
+        }
+
+        return targetIds;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -38,4 +38,6 @@ public interface ServiceDiscoveryService {
 
     Object getLaunchConfigObject(Service service, String launchConfigName, String objectName);
 
+    boolean isActiveService(Service service);
+
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -8,6 +8,7 @@ import static io.cattle.platform.core.model.tables.LoadBalancerTable.LOAD_BALANC
 import static io.cattle.platform.core.model.tables.ServiceTable.SERVICE;
 import io.cattle.iaas.lb.service.LoadBalancerService;
 import io.cattle.platform.allocator.service.AllocatorService;
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.LoadBalancerConstants;
 import io.cattle.platform.core.constants.NetworkConstants;
@@ -38,6 +39,7 @@ import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -713,6 +715,13 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
     public Object getLaunchConfigObject(Service service, String launchConfigName, String objectName) {
         Map<String, Object> serviceData = getLaunchConfigDataAsMap(service, launchConfigName);
         return serviceData.get(objectName);
+    }
+
+    @Override
+    public boolean isActiveService(Service service) {
+        List<String> validStates = Arrays.asList(CommonStatesConstants.ACTIVATING,
+                CommonStatesConstants.ACTIVE, CommonStatesConstants.UPDATING_ACTIVE);
+        return (validStates.contains(service.getState()));
     }
 
 }

--- a/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
+++ b/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
@@ -25,6 +25,7 @@
     <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerRemovePostListener" />
     <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerTargetAddPostListener" />
     <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerTargetRemovePostListener" />
+    <bean class="io.cattle.platform.servicediscovery.process.LoadBalancerServiceActivatePostListener" />
 
     <bean class="io.cattle.platform.servicediscovery.process.HostActivatePostHandler" />
     <bean class="io.cattle.platform.servicediscovery.process.HostLabelMapCreate" />


### PR DESCRIPTION
on other events, always check the lb service state, and don't propagate the targets if the state is Inactive. Otherwise targets updates kick off the lb agent start within the inactive service

https://github.com/rancherio/rancher/issues/902