### PR TITLE
Don't collect purged instances for services

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceExposeMapDaoImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceExposeMapDaoImpl.java
@@ -76,7 +76,8 @@ public class ServiceExposeMapDaoImpl extends AbstractJooqDao implements ServiceE
                 .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID)
                         .and(SERVICE_EXPOSE_MAP.SERVICE_ID.eq(serviceId))
                         .and(SERVICE_EXPOSE_MAP.STATE.in(CommonStatesConstants.ACTIVATING,
-                                CommonStatesConstants.ACTIVE, CommonStatesConstants.REQUESTED)))
+                                CommonStatesConstants.ACTIVE, CommonStatesConstants.REQUESTED))
+                        .and(INSTANCE.STATE.notIn(CommonStatesConstants.PURGING, CommonStatesConstants.PURGED)))
                 .fetchInto(InstanceRecord.class);
     }
 
@@ -88,9 +89,11 @@ public class ServiceExposeMapDaoImpl extends AbstractJooqDao implements ServiceE
                 .join(INSTANCE)
                 .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID)
                         .and(SERVICE_EXPOSE_MAP.SERVICE_ID.eq(serviceId))
-                        .and(SERVICE_EXPOSE_MAP.REMOVED.isNull().and(
-                                SERVICE_EXPOSE_MAP.STATE.notIn(CommonStatesConstants.REMOVED,
-                                        CommonStatesConstants.REMOVING))))
+                        .and(SERVICE_EXPOSE_MAP.REMOVED.isNull())
+                        .and(SERVICE_EXPOSE_MAP.STATE.notIn(CommonStatesConstants.REMOVED,
+                                CommonStatesConstants.REMOVING))
+                        .and(INSTANCE.STATE.notIn(CommonStatesConstants.PURGING,
+                                CommonStatesConstants.PURGED)))
                 .fetchInto(ServiceExposeMapRecord.class);
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryInstancePurgePreListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryInstancePurgePreListener.java
@@ -4,7 +4,7 @@ import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.ServiceExposeMap;
 import io.cattle.platform.engine.handler.HandlerResult;
-import io.cattle.platform.engine.handler.ProcessPostListener;
+import io.cattle.platform.engine.handler.ProcessPreListener;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
 import io.cattle.platform.object.process.StandardProcess;
@@ -23,7 +23,7 @@ import javax.inject.Named;
  * - separate handler takes care of that
  */
 @Named
-public class ServiceDiscoveryInstancePurgePostListener extends AbstractObjectProcessLogic implements ProcessPostListener,
+public class ServiceDiscoveryInstancePurgePreListener extends AbstractObjectProcessLogic implements ProcessPreListener,
         Priority {
     @Override
     public String[] getProcessNames() {
@@ -44,7 +44,7 @@ public class ServiceDiscoveryInstancePurgePostListener extends AbstractObjectPro
         for (ServiceExposeMap map : maps) {
             if (!(map.getState().equals(CommonStatesConstants.REMOVED) || map.getState().equals(
                     CommonStatesConstants.REMOVING))) {
-                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, map, null);
+                objectProcessManager.scheduleStandardProcessAsync(StandardProcess.REMOVE, map, null);
             }
         }
     }

--- a/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
+++ b/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
@@ -19,7 +19,7 @@
 
     <bean class="io.cattle.platform.servicediscovery.process.EnvironmentRemove" />
 
-    <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryInstancePurgePostListener" />
+    <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryInstancePurgePreListener" />
     <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryInstanceStartPostListener" />
 
     <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerRemovePostListener" />


### PR DESCRIPTION
And remove service-expose map as a pre-handler for instance.purge, not
post handler

Supposed to fix one of the TFs observed on Drone