### PR TITLE
Add machine binaries to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,14 @@ COPY ./scripts/bootstrap /scripts/bootstrap
 RUN /scripts/bootstrap
 WORKDIR /source
 COPY ./scripts/build-cache /scripts/build-cache
+
+# Adding static binaries
+ADD https://github.com/wlan0/machine/releases/download/v0.3.0-dev-packet/docker-machine /usr/bin/docker-machine
+RUN chmod +x /usr/bin/docker-machine
+
+ADD https://github.com/rancherio/go-machine-service/releases/download/v0.12.0/go-machine-service.tar.xz /tmp/
+RUN tar xpvf /tmp/go-machine-service.tar.xz -C /usr/bin/ && \
+    chmod +x /usr/bin/go-machine-service
+
+
 RUN /scripts/build-cache


### PR DESCRIPTION
As we develop services that are packaged with Rancher, we need to
have a way for them to be used during our development process.
Having them a part of cattle dockerfile will allow integration
testing along with build-master environments to have easier access
to development releases.

ping @ibuildthecloud /cc @cjellick @wlan0 