### PR TITLE
include updating-active state for when a host is updating labels

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/AllocatorDao.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/AllocatorDao.java
@@ -42,4 +42,6 @@ public interface AllocatorDao {
     Map<String, String> getLabelsForHost(long hostId);
 
     Multimap<String, String> getLabelsForContainersForHost(long hostId);
+
+    List<? extends Host> getActiveHosts(long accountId);
 }

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
@@ -389,4 +389,15 @@ public class AllocatorDaoImpl extends AbstractJooqDao implements AllocatorDao {
         }
         return labelsMap;
     }
+
+    @Override
+    public List<? extends Host> getActiveHosts(long accountId) {
+        return create()
+                .select(HOST.fields())
+                .from(HOST)
+                .where(HOST.REMOVED.isNull())
+                .and(HOST.ACCOUNT_ID.eq(accountId))
+                .and(HOST.STATE.in(CommonStatesConstants.ACTIVE, CommonStatesConstants.UPDATING_ACTIVE))
+                .fetchInto(Host.class);
+    }
 }

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocatorServiceImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocatorServiceImpl.java
@@ -1,6 +1,5 @@
 package io.cattle.platform.allocator.service;
 
-import static io.cattle.platform.core.model.tables.HostTable.HOST;
 import io.cattle.platform.allocator.constraint.AffinityConstraintDefinition;
 import io.cattle.platform.allocator.constraint.Constraint;
 import io.cattle.platform.allocator.constraint.ContainerAffinityConstraint;
@@ -8,7 +7,6 @@ import io.cattle.platform.allocator.constraint.ContainerLabelAffinityConstraint;
 import io.cattle.platform.allocator.constraint.HostAffinityConstraint;
 import io.cattle.platform.allocator.constraint.AffinityConstraintDefinition.AffinityOps;
 import io.cattle.platform.allocator.dao.AllocatorDao;
-import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.dao.InstanceDao;
 import io.cattle.platform.core.model.Environment;
 import io.cattle.platform.core.model.Host;
@@ -47,7 +45,7 @@ public class AllocatorServiceImpl implements AllocatorService {
 
     @Override
     public List<Long> getHostsSatisfyingHostAffinity(Long accountId, Map<String, String> labelConstraints) {
-        List<Host> hosts = objectManager.find(Host.class, HOST.ACCOUNT_ID, accountId, HOST.STATE, CommonStatesConstants.ACTIVE, HOST.REMOVED, null);
+        List<? extends Host> hosts = allocatorDao.getActiveHosts(accountId);
 
         List<Constraint> hostAffinityConstraints = getHostAffinityConstraintsFromLabels(labelConstraints);
 


### PR DESCRIPTION
This fixes a problem where the labels for a host would get updated.  The hostLabelMap changes triggers a reconciliation of the global service.  However, the currently updating host would not be considered since it's in updating-active state.