### PR TITLE
Deactivate/acivate LB along with LB service

### DIFF
--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
@@ -109,12 +109,13 @@ public class LoadBalancerUpdateConfig extends AbstractObjectProcessLogic impleme
         for (Long lbId : lbIds) {
             LoadBalancer lb = objectManager.loadResource(LoadBalancer.class, lbId);
             List<String> activeStates = Arrays.asList(CommonStatesConstants.ACTIVATING, CommonStatesConstants.ACTIVE, CommonStatesConstants.UPDATING_ACTIVE);
+
             if (activeStates.contains(lb.getState())) {
                 activeLbIds.add(lbId);
             }
         }
 
-        Map<Long, List<? extends Instance>> lbInstancesMap = createLoadBalancerInstances(state, process, lbIds);
+        Map<Long, List<? extends Instance>> lbInstancesMap = createLoadBalancerInstances(state, process, activeLbIds);
 
         updateLoadBalancerConfigs(state, lbInstancesMap);
 

--- a/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
+++ b/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
@@ -119,7 +119,9 @@
 
     <!-- Load Balancer -->
     <process:process name="loadbalancer.create" resourceType="loadBalancer" start="requested" transitioning="activating" done="active" />
-    <process:process name="loadbalancer.remove" resourceType="loadBalancer" start="active, activating, updating-active" transitioning="removing" done="removed" />
+    <process:process name="loadbalancer.activate" resourceType="loadBalancer" start="inactive" transitioning="activating" done="active" />
+    <process:process name="loadbalancer.deactivate" resourceType="loadBalancer" start="active,activating, updating-active" transitioning="deactivating" done="inactive" />
+    <process:process name="loadbalancer.remove" resourceType="loadBalancer" start="active, activating, updating-active, inactive, deactivating" transitioning="removing" done="removed" />
     <process:process name="loadbalancer.update" resourceType="loadBalancer" start="active" transitioning="updating-active" done="active" />
 
     <!-- Load Balancer Target -->

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceActivatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceActivatePostListener.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
+@Named
 public class LoadBalancerServiceActivatePostListener extends AbstractObjectProcessLogic implements ProcessPostListener,
         Priority {
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceActivatePreListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceActivatePreListener.java
@@ -1,0 +1,48 @@
+package io.cattle.platform.servicediscovery.process;
+
+import static io.cattle.platform.core.model.tables.LoadBalancerTable.LOAD_BALANCER;
+import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.model.LoadBalancer;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPreListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.object.process.StandardProcess;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
+import io.cattle.platform.util.type.Priority;
+
+import javax.inject.Named;
+
+@Named
+public class LoadBalancerServiceActivatePreListener extends AbstractObjectProcessLogic implements ProcessPreListener,
+        Priority {
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { ServiceDiscoveryConstants.PROCESS_SERVICE_ACTIVATE };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Service service = (Service) state.getResource();
+
+        if (!service.getKind().equalsIgnoreCase(ServiceDiscoveryConstants.KIND.LOADBALANCERSERVICE.name())) {
+            return null;
+        }
+
+        LoadBalancer lb = objectManager.findOne(LoadBalancer.class, LOAD_BALANCER.SERVICE_ID, service.getId(),
+                LOAD_BALANCER.REMOVED, null);
+        if (lb != null && lb.getState().equalsIgnoreCase(CommonStatesConstants.INACTIVE)) {
+            objectProcessManager.scheduleStandardProcessAsync(StandardProcess.ACTIVATE, lb, null);
+        }
+        return null;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceDeactivatePreListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceDeactivatePreListener.java
@@ -1,0 +1,51 @@
+package io.cattle.platform.servicediscovery.process;
+
+import static io.cattle.platform.core.model.tables.LoadBalancerTable.LOAD_BALANCER;
+import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.model.LoadBalancer;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPreListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.object.process.StandardProcess;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
+import io.cattle.platform.util.type.Priority;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class LoadBalancerServiceDeactivatePreListener extends AbstractObjectProcessLogic implements ProcessPreListener,
+        Priority {
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { ServiceDiscoveryConstants.PROCESS_SERVICE_DEACTIVATE };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Service service = (Service) state.getResource();
+
+        if (!service.getKind().equalsIgnoreCase(ServiceDiscoveryConstants.KIND.LOADBALANCERSERVICE.name())) {
+            return null;
+        }
+
+        LoadBalancer lb = objectManager.findOne(LoadBalancer.class, LOAD_BALANCER.SERVICE_ID, service.getId(),
+                LOAD_BALANCER.REMOVED, null);
+
+        List<String> activeStates = Arrays.asList(CommonStatesConstants.ACTIVATING, CommonStatesConstants.ACTIVE,
+                CommonStatesConstants.UPDATING_ACTIVE);
+
+        if (lb != null && activeStates.contains(lb.getState())) {
+            objectProcessManager.scheduleStandardProcessAsync(StandardProcess.DEACTIVATE, lb, null);
+        }
+        return null;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryLoadBalancerTargetRemovePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryLoadBalancerTargetRemovePostListener.java
@@ -80,7 +80,7 @@ public class ServiceDiscoveryLoadBalancerTargetRemovePostListener extends Abstra
                 Service lbService = objectManager.loadResource(Service.class, consumingServiceMap.getServiceId());
                 if (lbService.getKind().equalsIgnoreCase(KIND.LOADBALANCERSERVICE.name())) {
                     if (!sdService.isActiveService(lbService)) {
-                        return;
+                        continue;
                     }
                     LoadBalancer lb = objectManager.findOne(LoadBalancer.class, LOAD_BALANCER.SERVICE_ID,
                             lbService.getId(),

--- a/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
+++ b/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
@@ -26,6 +26,8 @@
     <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerTargetAddPostListener" />
     <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryLoadBalancerTargetRemovePostListener" />
     <bean class="io.cattle.platform.servicediscovery.process.LoadBalancerServiceActivatePostListener" />
+    <bean class="io.cattle.platform.servicediscovery.process.LoadBalancerServiceActivatePreListener" />
+    <bean class="io.cattle.platform.servicediscovery.process.LoadBalancerServiceDeactivatePreListener" />
 
     <bean class="io.cattle.platform.servicediscovery.process.ServicesReconcilePostTrigger" />
     <bean class="io.cattle.platform.servicediscovery.process.ServicesReconcileTrigger" />

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -96,11 +96,13 @@ def test_deactivate_then_activate_lb_svc(super_client, new_context):
     validate_add_host(host2, lb, client)
 
     lb = super_client.reload(lb)
-    assert lb.state == "active"
+    assert lb.state == "inactive"
 
     # 3. activate service again
     service = client.wait_success(service.activate())
     assert service.state == 'active'
+    lb = super_client.reload(lb)
+    assert lb.state == "active"
     _validate_lb_instance(host1, lb, super_client, service)
     _validate_lb_instance(host2, lb, super_client, service)
 
@@ -121,7 +123,7 @@ def test_deactivate_then_remove_lb_svc(new_context):
     validate_add_host(host2, lb, client)
 
     lb = client.reload(lb)
-    assert lb.state == "active"
+    assert lb.state == "inactive"
 
     # try to remove lb - should fail
     with pytest.raises(ApiError) as e:


### PR DESCRIPTION
When service is activated, activate the LB. When deactivated -
deactivate. If LB is left in Active state when LB service is inactive,
LB update caused by target instance.stop/instance.start would trigger LB
instance restart within the inactive service

https://github.com/rancherio/rancher/issues/902