### PR TITLE
Add read on create only support

### DIFF
--- a/code/framework/api/src/main/java/io/cattle/platform/api/utils/ApiUtils.java
+++ b/code/framework/api/src/main/java/io/cattle/platform/api/utils/ApiUtils.java
@@ -175,8 +175,8 @@ public class ApiUtils {
 
                 additionalFields.putAll(attachments);
             }
-
-            return new WrappedResource(idFormatter, schema, obj, additionalFields, PRIORITY_FIELDS);
+            String method = request == null ? null : request.getMethod();
+            return new WrappedResource(idFormatter, schema, obj, additionalFields, PRIORITY_FIELDS, method);
         } finally {
             DEPTH.set(depth);
         }

--- a/code/framework/schema/src/main/java/io/cattle/platform/schema/processor/AuthOverlayPostProcessor.java
+++ b/code/framework/schema/src/main/java/io/cattle/platform/schema/processor/AuthOverlayPostProcessor.java
@@ -79,6 +79,7 @@ public class AuthOverlayPostProcessor implements SchemaPostProcessor {
             FieldImpl fieldImpl = (FieldImpl) field;
             fieldImpl.setCreate(perm.isCreate());
             fieldImpl.setUpdate(perm.isUpdate());
+            fieldImpl.setReadOnCreateOnly(perm.isReadOnCreateOnly());
         }
         Iterator<Map.Entry<String, Action>> actionIter = schema.getResourceActions().entrySet().iterator();
 
@@ -197,7 +198,7 @@ public class AuthOverlayPostProcessor implements SchemaPostProcessor {
     }
 
     private static class Perm {
-        boolean read, create, update, delete;
+        boolean read, create, update, delete, readOnCreateOnly;
 
         public Perm(String value) {
             super();
@@ -205,6 +206,7 @@ public class AuthOverlayPostProcessor implements SchemaPostProcessor {
             read = value.contains("r");
             update = value.contains("u");
             delete = value.contains("d");
+            readOnCreateOnly = value.contains("o");
         }
 
         public boolean isRead() {
@@ -221,6 +223,10 @@ public class AuthOverlayPostProcessor implements SchemaPostProcessor {
 
         public boolean isDelete() {
             return delete;
+        }
+
+        public boolean isReadOnCreateOnly() {
+            return readOnCreateOnly;
         }
     }
 

--- a/code/meta-parent/pom.xml
+++ b/code/meta-parent/pom.xml
@@ -379,7 +379,7 @@
             <dependency>
                 <groupId>io.github.ibuildthecloud</groupId>
                 <artifactId>gdapi-java-server</artifactId>
-                <version>0.11.1.1</version>
+                <version>0.11.3</version>
             </dependency>
             <dependency>
                 <groupId>commons-collections</groupId>


### PR DESCRIPTION
This makes it so that you can add "o" as a permission on a resourceField.
When "o" is present that field is only returned when the resource is created
for that schema. All other requests exclude the field.