### PR TITLE
Service discovery bug fixes

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/HealthcheckInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/HealthcheckInfoDaoImpl.java
@@ -99,7 +99,7 @@ public class HealthcheckInfoDaoImpl extends AbstractJooqDao implements Healthche
                         .and(IP_ADDRESS_NIC_MAP.REMOVED.isNull())
                         .and(targetNic.REMOVED.isNull())
                         .and(targetInstance.STATE.in(InstanceConstants.STATE_RUNNING,
-                                InstanceConstants.STATE_STARTING, InstanceConstants.STATE_RESTARTING))
+                                InstanceConstants.STATE_STARTING))
                         .and(HEALTHCHECK_INSTANCE.INSTANCE_ID.isNotNull()))
                 .fetch().map(mapper);
     }

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
@@ -186,7 +186,9 @@ public class InstanceStart extends AbstractDefaultProcessHandler {
         }
 
         for (InstanceLink link : getObjectManager().children(instance, InstanceLink.class, InstanceLinkConstants.FIELD_INSTANCE_ID)) {
-            activate(link, state.getData());
+            if (link.getRemoved() == null) {
+                activate(link, state.getData());
+            }
         }
     }
 

--- a/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
+++ b/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
@@ -153,7 +153,7 @@
     <process:process name="service.activate" resourceType="service" start="inactive" transitioning="activating" done="active" />    
     <process:process name="service.update" resourceType="service" start="inactive,active" transitioning="inactive=updating-inactive,active=updating-active" done="updating-inactive=inactive,updating-active=active" />
     <process:process name="service.deactivate" resourceType="service" start="active,activating, updating-inactive, updating-active" transitioning="deactivating" done="inactive" />
-    <process:process name="service.remove" resourceType="service" start="inactive, registering, active, activating, updating-inactive, updating-active" transitioning="removing" done="removed" />
+    <process:process name="service.remove" resourceType="service" start="inactive, registering, active, activating, updating-inactive, updating-active, deactivating" transitioning="removing" done="removed" />
     
     <!-- Service Discovery Service/Instance map -->
     <process:process name="serviceexposemap.create" resourceType="serviceExposeMap" start="requested" transitioning="activating" done="active" />

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -1,6 +1,5 @@
 package io.cattle.platform.servicediscovery.api.constants;
 
-
 public class ServiceDiscoveryConstants {
 
     public enum KIND {
@@ -23,6 +22,7 @@ public class ServiceDiscoveryConstants {
     public static final String FIELD_NETWORK_LAUNCH_CONFIG = "networkLaunchConfig";
     public static final String FIELD_SECONDARY_LAUNCH_CONFIGS = "secondaryLaunchConfigs";
     public static final String FIELD_DATA_VOLUMES_LAUNCH_CONFIG = "dataVolumesFromLaunchConfigs";
+    public static final String FIELD_WAIT_FOR_CONSUMED_SERVICES_IDS = "waitForConsumedServicesIds";
 
     public static final String ACTION_SERVICE_ACTIVATE = "activate";
     public static final String ACTION_SERVICE_CREATE = "create";

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -71,4 +71,6 @@ public abstract class DeploymentUnitInstance {
     public Service getService() {
         return service;
     }
+
+    public abstract void waitForNotTransitioning();
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DefaultDeploymentUnitInstance.java
@@ -94,7 +94,7 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
 
     @Override
     public DeploymentUnitInstance waitForStart() {
-        this.instance = context.resourceMonitor.waitFor(context.objectManager.reload(this.instance),
+        this.instance = context.resourceMonitor.waitFor(this.instance,
                 new ResourcePredicate<Instance>() {
             @Override
             public boolean evaluate(Instance obj) {
@@ -130,6 +130,13 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
                     HealthcheckConstants.HEALTH_STATE_UPDATING_UNHEALTHY));
         }
         return false;
+    }
+
+    @Override
+    public void waitForNotTransitioning() {
+        if (this.instance != null) {
+            this.instance = context.resourceMonitor.waitForNotTransitioning(this.instance);
+        }
     }
 }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
@@ -271,7 +271,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
         for (Service service: services) {
             ConfigUpdateRequest request = ConfigUpdateRequest.forResource(Service.class, service.getId());
             request.addItem(RECONCILE);
-
+            request.withDeferredTrigger(true);
             itemManager.updateConfig(request);
         }
     }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
@@ -171,7 +171,7 @@ public class DeploymentUnit {
     protected DeploymentUnitInstance createInstance(String launchConfigName, Service service) {
         List<Integer> volumesFromInstanceIds = getVolumesFromInstancesIds(service, launchConfigName);
         Integer networkContainerId = getNetworkContainerId(launchConfigName, service);
-        
+        getDeploymentUnitInstance(service, launchConfigName).waitForNotTransitioning();
         getDeploymentUnitInstance(service, launchConfigName)
                 .start(
                         populateDeployParams(getDeploymentUnitInstance(service, launchConfigName),

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ExternalDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ExternalDeploymentUnitInstance.java
@@ -1,7 +1,6 @@
 package io.cattle.platform.servicediscovery.deployment.impl;
 
 import io.cattle.platform.core.constants.CommonStatesConstants;
-import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceExposeMap;
 import io.cattle.platform.deferred.util.DeferredUtils;
@@ -85,6 +84,13 @@ public class ExternalDeploymentUnitInstance extends DeploymentUnitInstance {
     @Override
     public boolean isUnhealthy() {
         return false;
+    }
+
+    @Override
+    public void waitForNotTransitioning() {
+        if (this.exposeMap != null) {
+            this.exposeMap = context.resourceMonitor.waitForNotTransitioning(this.exposeMap);
+        }
     }
 
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/LoadBalancerDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/LoadBalancerDeploymentUnitInstance.java
@@ -123,4 +123,11 @@ public class LoadBalancerDeploymentUnitInstance extends DeploymentUnitInstance i
         }
         return false;
     }
+
+    @Override
+    public void waitForNotTransitioning() {
+        if (this.hostMap != null) {
+            this.hostMap = context.resourceMonitor.waitForNotTransitioning(this.hostMap);
+        }
+    }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -224,7 +224,7 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
 
     private void populateLinksForService(Service service, Collection<Long> servicesToExportIds,
             Map<String, Object> composeServiceData) {
-        Map<String, String> serviceLinksWithNames = new HashMap<>();
+        List<String> serviceLinksWithNames = new ArrayList<>();
         List<Service> externalLinksServices = new ArrayList<>();
         List<? extends ServiceConsumeMap> consumedServiceMaps = consumeMapDao.findConsumedServices(service.getId());
         for (ServiceConsumeMap consumedServiceMap : consumedServiceMaps) {
@@ -233,7 +233,7 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
             if (servicesToExportIds.contains(consumedServiceMap.getConsumedServiceId())) {
                 String linkName = consumedServiceMap.getName() != null ? consumedServiceMap.getName() : consumedService
                         .getName();
-                serviceLinksWithNames.put(consumedService.getName(), linkName);
+                serviceLinksWithNames.add(consumedService.getName() + ":" + linkName);
             } else {
                 externalLinksServices.add(consumedService);
             }
@@ -248,7 +248,7 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
     private void populateExternalLinksForService(Service service, Map<String, Object> composeServiceData,
             List<Service> externalLinksServices) {
 
-        Map<String, String> instanceLinksWithNames = new LinkedHashMap<String, String>();
+        Map<String, String> instanceLinksWithNamesMaps = new LinkedHashMap<String, String>();
         Map<String, Object> instanceLinksWithIds = (Map<String, Object>) composeServiceData
                 .get(ServiceDiscoveryConfigItem.EXTERNALLINKS
                 .getDockerName());
@@ -259,7 +259,7 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
                         null);
                 String instanceName = getInstanceName(instance);
                 if (instanceName != null) {
-                    instanceLinksWithNames.put(instanceName, linkName);
+                    instanceLinksWithNamesMaps.put(instanceName, linkName);
                 }
             }
         }
@@ -269,11 +269,15 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
             for (Instance instance : instances) {
                 String instanceName = getInstanceName(instance);
                 if (instanceName != null) {
-                    instanceLinksWithNames.put(instanceName, instanceName);
+                    instanceLinksWithNamesMaps.put(instanceName, instanceName);
                 }
             }
         }
-        if (!instanceLinksWithNames.isEmpty()) {
+        if (!instanceLinksWithNamesMaps.isEmpty()) {
+            List<String> instanceLinksWithNames = new ArrayList<>();
+            for (String instanceLinkName : instanceLinksWithNamesMaps.keySet()) {
+                instanceLinksWithNames.add(instanceLinksWithNamesMaps.get(instanceLinkName) + ":" + instanceLinkName);
+            }
             composeServiceData.put(ServiceDiscoveryConfigItem.EXTERNALLINKS.getDockerName(), instanceLinksWithNames);
         }
     }


### PR DESCRIPTION
1) Exclude Restarting instances from healtcheck

https://github.com/rancherio/rancher/issues/1180

2) Launch services in order from environment.activateServices

3)  And added missing state transition - allow service.remove from deactivating state

4)  Skip activation for removed links during instance.start

5) Wait for nonTransition state on service instances before performing any action

https://github.com/rancherio/rancher/issues/1254

6)  Don't explicitly clean env in tests as they are removed as a part of account.purge

7) Export links as array of strings (not map) to compose

https://github.com/rancherio/rancher/issues/1120