### PR TITLE
Add machine related binaries

### DIFF
--- a/resources/content/cattle-global.properties
+++ b/resources/content/cattle-global.properties
@@ -19,6 +19,8 @@ rancher.compose.linux.url=https://github.com/rancherio/rancher-compose/releases/
 rancher.compose.darwin.url=https://github.com/rancherio/rancher-compose/releases/download/v0.1.0/rancher-compose_darwin-amd64
 rancher.compose.windows.url=https://github.com/rancherio/rancher-compose/releases/download/v0.1.0/rancher-compose_windows-386.exe
 service.package.websocket.proxy.url=https://github.com/rancherio/websocket-proxy/releases/download/v0.1.1/websocket-proxy.tar.xz
+service.package.go.machine.service.url=https://github.com/rancherio/go-machine-service/releases/download/v0.13.0/go-machine-service.tar.xz
+service.package.docker.machine.url=https://github.com/rancherio/machine/releases/download/v0.3.0-dev-packet-rc2/docker-machine
 
 ####################
 # General Settings #

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -10,6 +10,18 @@ DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o D
 
 pip install --upgrade pip==6.0.3 tox==1.8.1 virtualenv==12.0.4
 
+install_build_tools()
+{
+	BUILD_TOOLS_VERSION="0.1.0"
+	tmpdir=$(mktemp -d)
+	pushd $tmpdir
+	curl -sSL -o build-tools.tar.gz https://github.com/rancherio/build-tools/archive/v${BUILD_TOOLS_VERSION}.tar.gz
+	tar -xzvf build-tools.tar.gz && cp ./build-tools-${BUILD_TOOLS_VERSION}/bin/* /usr/bin
+	popd
+	rm -rf ${tmpdir}
+}
+install_build_tools
+
 if [ "${CATTLE_DB_CATTLE_DATABASE}" == "mysql" ]; then
     sed -i "0,/3306/! {0,/3306/ s/3306/${CATTLE_DB_CATTLE_MYSQL_PORT}/}" /etc/mysql/my.cnf
     service mysql start
@@ -33,9 +45,6 @@ if [ "${CATTLE_DB_CATTLE_DATABASE}" == "mysql" ]; then
     fi
 fi
 
-if [ -f ../resources/content/cattle-global.properties ]; then
-    websocket_proxy_url=$(grep 'service.package.websocket.proxy.url' ../resources/content/cattle-global.properties | awk -F= '{print $2}')
-    curl -L -o websocket_proxy.tar.xz $websocket_proxy_url
-    tar xpvf websocket_proxy.tar.xz -C /usr/bin && chmod +x /usr/bin/websocket-proxy
-    echo "Installed websocket-proxy"
+if [ -x /usr/bin/cattle-binary-pull ] && [ -f ../resources/content/cattle-global.properties ]; then
+    /usr/bin/cattle-binary-pull ../resources/content/cattle-global.properties /usr/bin
 fi


### PR DESCRIPTION
Uses the build-tool cattle-binary-pull to get the go-machine-service, websocket-proxy and docker-machine binary. Updated the cattle-global.properties file to pull from this now.
