### PR TITLE
Compose: don't export null values

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/resource/ServiceDiscoveryConfigItem.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/resource/ServiceDiscoveryConfigItem.java
@@ -52,14 +52,13 @@ public class ServiceDiscoveryConfigItem {
             DockerInstanceConstants.FIELD_NETWORK_MODE,
             "net");
 
+    public static final ServiceDiscoveryConfigItem LABELS = new ServiceDiscoveryConfigItem(
+            InstanceConstants.FIELD_LABELS, InstanceConstants.FIELD_LABELS,
+            true, true);
+
     // CATTLE PARAMETERS
     public static final ServiceDiscoveryConfigItem SCALE = new ServiceDiscoveryConfigItem("scale", "scale",
             false, false);
-    public static final ServiceDiscoveryConfigItem CPU_SET = new ServiceDiscoveryConfigItem("cpuSet",
-            "cpu_set", true, false);
-    public static final ServiceDiscoveryConfigItem REQUESTED_HOST_ID = new ServiceDiscoveryConfigItem(
-            InstanceConstants.FIELD_REQUESTED_HOST_ID, InstanceConstants.FIELD_REQUESTED_HOST_ID,
-            true, false);
     public static final ServiceDiscoveryConfigItem HEALTHCHECK = new ServiceDiscoveryConfigItem(
             InstanceConstants.FIELD_HEALTH_CHECK,
             NamedUtils.toUnderscoreSeparated(InstanceConstants.FIELD_HEALTH_CHECK),
@@ -69,10 +68,6 @@ public class ServiceDiscoveryConfigItem {
             ServiceDiscoveryConstants.FIELD_LOAD_BALANCER_CONFIG,
             NamedUtils.toUnderscoreSeparated(ServiceDiscoveryConstants.FIELD_LOAD_BALANCER_CONFIG),
             false, false);
-
-    public static final ServiceDiscoveryConfigItem LABELS = new ServiceDiscoveryConfigItem(
-            InstanceConstants.FIELD_LABELS, InstanceConstants.FIELD_LABELS,
-            true, true);
 
     public static final ServiceDiscoveryConfigItem EXTERNAL_IPS = new ServiceDiscoveryConfigItem(
             ServiceDiscoveryConstants.FIELD_EXTERNALIPS,

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/RancherGenericMapToComposeFormatter.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/RancherGenericMapToComposeFormatter.java
@@ -31,8 +31,9 @@ public class RancherGenericMapToComposeFormatter implements RancherConfigToCompo
                 if (map.get(key) instanceof Map) {
                     lowerCaseParameters(map.get(key));
                 }
-
-                newMap.put(NamedUtils.toUnderscoreSeparated(key), map.get(key));
+                if (map.get(key) != null) {
+                    newMap.put(NamedUtils.toUnderscoreSeparated(key), map.get(key));
+                }
                 it.remove();
             }
             map.putAll(newMap);


### PR DESCRIPTION
1) Don't include null values to docker/rancher-compose.yml
2) Remove requestedHostId/cpuSet from rancher-compose (used to keep there
as docker-compose doesn't support these params, but never read them). We can re-enable cpuSet, but to put it to the docker-compose.yml once docker-compose starts supporting it (https://github.com/docker/compose/issues/754)