### PR TITLE
Log first database connection error

### DIFF
--- a/code/framework/archaius/src/main/java/io/cattle/platform/archaius/sources/LazyJDBCSource.java
+++ b/code/framework/archaius/src/main/java/io/cattle/platform/archaius/sources/LazyJDBCSource.java
@@ -19,6 +19,7 @@ public class LazyJDBCSource implements PolledConfigurationSource {
 
     JDBCConfigurationSource source;
     boolean firstLoad = true;
+    boolean firstDbError = true;
 
     @Override
     public PollResult poll(boolean initial, Object checkPoint) throws Exception {
@@ -50,7 +51,12 @@ public class LazyJDBCSource implements PolledConfigurationSource {
                     break;
                 } catch (SQLException e) {
                     connectionGood = false;
-                    log.error("Failed to get connection to database, will retry for 5 minutes");
+                    if (firstDbError) {
+                        firstDbError = false;
+                        log.error("Failed to get connection to database, will retry for 5 minutes", e);
+                    } else {
+                        log.error("Failed to get connection to database, will retry for 5 minutes");
+                    }
                     try {
                         Thread.sleep(1000);
                     } catch (InterruptedException t) {


### PR DESCRIPTION
The exception may be helpful to debug a database error. Log it on first
attempt, then don't log it anymore.

I was trying to use the h2 backend but the generic message was unhelpful.